### PR TITLE
feat: register dashboard component dynamically using signals

### DIFF
--- a/socialmedia/signals.py
+++ b/socialmedia/signals.py
@@ -4,14 +4,9 @@ from django.urls import resolve, reverse
 from django.utils.translation import gettext_lazy as _
 from eventyay.control.signals import (
     event_dashboard_components,
-    nav_event,
+    nav_event_common,
     nav_global,
 )
-
-try:
-    from eventyay.control.signals import nav_event_common
-except ImportError:
-    nav_event_common = None
 
 
 @receiver(nav_global, dispatch_uid="socialmedia_nav")
@@ -19,34 +14,27 @@ def control_nav_socialmedia(sender, request=None, **kwargs):
     return []
 
 
-@receiver(nav_event, dispatch_uid="socialmedia_nav_event")
-def control_nav_event_socialmedia(sender, request=None, **kwargs):
-    return []
-
-
-if nav_event_common:
-
-    @receiver(nav_event_common, dispatch_uid="socialmedia_nav_event_common")
-    def control_nav_event_common_socialmedia(sender, request=None, **kwargs):
-        if not request or not request.user.is_authenticated:
-            return []
-        url = resolve(request.path_info)
-        return [
-            {
-                "label": _("Social Media"),
-                "url": reverse(
-                    "plugins:socialmedia:index",
-                    kwargs={
-                        "organizer": sender.organizer.slug,
-                        "event": sender.slug,
-                    },
-                ),
-                "icon": "share-alt",
-                "active": (
-                    url.namespace == "plugins:socialmedia" and url.url_name == "index"
-                ),
-            }
-        ]
+@receiver(nav_event_common, dispatch_uid="socialmedia_nav_event_common")
+def control_nav_event_common_socialmedia(sender, request=None, **kwargs):
+    if not request or not request.user.is_authenticated:
+        return []
+    url = resolve(request.path_info)
+    return [
+        {
+            "label": _("Social Media"),
+            "url": reverse(
+                "plugins:socialmedia:index",
+                kwargs={
+                    "organizer": sender.organizer.slug,
+                    "event": sender.slug,
+                },
+            ),
+            "icon": "share-alt",
+            "active": (
+                url.namespace == "plugins:socialmedia" and url.url_name == "index"
+            ),
+        }
+    ]
 
 
 @receiver(event_dashboard_components, dispatch_uid="socialmedia_dashboard_components")

--- a/socialmedia/signals.py
+++ b/socialmedia/signals.py
@@ -1,5 +1,10 @@
 from django.dispatch import receiver
-from eventyay.control.signals import nav_event, nav_global
+from django.template.loader import render_to_string
+from eventyay.control.signals import (
+    event_dashboard_components,
+    nav_event,
+    nav_global,
+)
 
 
 @receiver(nav_global, dispatch_uid="socialmedia_nav")
@@ -10,3 +15,12 @@ def control_nav_socialmedia(sender, request=None, **kwargs):
 @receiver(nav_event, dispatch_uid="socialmedia_nav_event")
 def control_nav_event_socialmedia(sender, request=None, **kwargs):
     return []
+
+
+@receiver(event_dashboard_components, dispatch_uid="socialmedia_dashboard_components")
+def control_dashboard_socialmedia(sender, request=None, **kwargs):
+    return render_to_string(
+        "socialmedia/dashboard_component.html",
+        {"request": request},
+        request=request,
+    )

--- a/socialmedia/signals.py
+++ b/socialmedia/signals.py
@@ -1,10 +1,17 @@
 from django.dispatch import receiver
 from django.template.loader import render_to_string
+from django.urls import resolve, reverse
+from django.utils.translation import gettext_lazy as _
 from eventyay.control.signals import (
     event_dashboard_components,
     nav_event,
     nav_global,
 )
+
+try:
+    from eventyay.control.signals import nav_event_common
+except ImportError:
+    nav_event_common = None
 
 
 @receiver(nav_global, dispatch_uid="socialmedia_nav")
@@ -15,6 +22,31 @@ def control_nav_socialmedia(sender, request=None, **kwargs):
 @receiver(nav_event, dispatch_uid="socialmedia_nav_event")
 def control_nav_event_socialmedia(sender, request=None, **kwargs):
     return []
+
+
+if nav_event_common:
+
+    @receiver(nav_event_common, dispatch_uid="socialmedia_nav_event_common")
+    def control_nav_event_common_socialmedia(sender, request=None, **kwargs):
+        if not request or not request.user.is_authenticated:
+            return []
+        url = resolve(request.path_info)
+        return [
+            {
+                "label": _("Social Media"),
+                "url": reverse(
+                    "plugins:socialmedia:index",
+                    kwargs={
+                        "organizer": sender.organizer.slug,
+                        "event": sender.slug,
+                    },
+                ),
+                "icon": "share-alt",
+                "active": (
+                    url.namespace == "plugins:socialmedia" and url.url_name == "index"
+                ),
+            }
+        ]
 
 
 @receiver(event_dashboard_components, dispatch_uid="socialmedia_dashboard_components")

--- a/socialmedia/templates/socialmedia/dashboard_component.html
+++ b/socialmedia/templates/socialmedia/dashboard_component.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+<div class="panel panel-default widget-container widget-small no-padding column">
+    <div class="panel-heading">
+        <h3 class="panel-title">
+            {% trans "Social Media" %}
+        </h3>
+    </div>
+    <div class="panel-body">
+        <p>
+            {% trans "Automate and schedule social media announcements for your event. Customize templates, set trigger offsets, and export announcements to CSV." %}
+        </p>
+        <p>
+            {% trans "Go to" %} <a href="{% url 'plugins:socialmedia:index' organizer=request.organizer.slug event=request.event.slug %}">{% trans "Social Media Dashboard" %}</a>
+        </p>
+    </div>
+</div>

--- a/socialmedia/views.py
+++ b/socialmedia/views.py
@@ -18,7 +18,7 @@ def index(request, organizer, event):
         raise PermissionDenied()
 
     # Check if the plugin is active for the event
-    if not request.event.is_socialmedia_enabled:
+    if "socialmedia" not in request.event.get_plugins():
         raise Http404("Social Media plugin is not enabled for this event.")
 
     # Populate navigation items for the sidebar


### PR DESCRIPTION
# Description

This PR shifts the integration of the Event Common Dashboard card from a hardcoded template approach in the core repository to a dynamic, signal-driven architecture. 

*(Note: The main scaffolding, top-level routing, permissions checks, and clean sidebar hooks of Phase 1 (#8) were already introduced and merged via #12. This PR completes the final piece of #8 by migrating the dashboard card integration to a dynamic signal format).*

- Resolves #8 

## Changes Made

- **Signal Hook Registration:** Added a receiver for `event_dashboard_components` in `socialmedia/signals.py`.
- **Dynamic Card Template:** Created `socialmedia/templates/socialmedia/dashboard_component.html` to house the markup for the Social Media widget panel.
