### PR TITLE
chore: fix CI/CD pipelines and add view test suite

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -13,8 +13,8 @@ on:
       - 'socialmedia/static/**'
 
 jobs:
-  ruff:
-    name: ruff
+  pre-commit:
+    name: pre-commit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,9 +30,7 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install pretix
         run: pip3 install pretix
-      - name: Install Dependencies
-        run: pip3 install -U ruff -e .
-      - name: Run ruff check
-        run: ruff check .
-      - name: Run ruff format
-        run: ruff format --check .
+      - name: Install pre-commit
+        run: pip3 install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,24 +13,73 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: Tests
+    name: Social Media Plugin Tests
+    
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: eventyay-db
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - name: Checkout eventyay_socialmedia plugin
+        uses: actions/checkout@v6
+
+      - name: Clone eventyay
+        run: |
+          git clone https://github.com/fossasia/eventyay.git ../eventyay
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.12
-      - uses: actions/cache@v4
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          enable-cache: true
+
       - name: Install system dependencies
-        run: sudo apt update && sudo apt install gettext
-      - name: Install pretix
-        run: pip3 install pretix
-      - name: Install Dependencies
-        run: pip3 install -U pytest pytest-django -e .
-      - name: Run checks
-        run: py.test tests
+        run: sudo apt-get update && sudo apt-get install -y gettext libjpeg-dev zlib1g-dev libpq-dev
+
+      - name: Set up eventyay environment
+        run: |
+          cd ../eventyay/app
+          uv sync --all-extras --all-groups
+          # Install socialmedia plugin and coverage in the eventyay environment
+          uv pip install pytest-cov
+          uv pip install -e ../../eventyay-socialmedia
+
+      - name: Compile translations
+        run: |
+          . ../eventyay/app/.venv/bin/activate
+          make
+
+      - name: Run tests with coverage
+        env:
+          EVY_RUNNING_ENVIRONMENT: testing
+          EVY_POSTGRES_HOST: localhost
+          EVY_POSTGRES_PORT: 5432
+          EVY_POSTGRES_USER: postgres
+          EVY_POSTGRES_PASSWORD: postgres
+          EVY_POSTGRES_DB: eventyay-db
+        run: |
+          . ../eventyay/app/.venv/bin/activate
+          pytest tests --cov=socialmedia --cov-report=xml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,13 +15,11 @@ style:
         name: pretix/ci-image
     before_script:
         - pip install -U pip uv
-        - uv pip install --system -U wheel setuptools isort black flake8 check-manifest
+        - uv pip install --system -U wheel setuptools pre-commit check-manifest
         - uv pip install --system -U git+https://github.com/pretix/pretix.git@master#egg=pretix
     script:
         - uv pip install --system -e .
-        - black --check .
-        - isort -c --gitignore .
-        - flake8 --extend-exclude .cache .
+        - pre-commit run --all-files
         - check-manifest --ignore .cache .
 pypi:
     image:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.5
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,47 @@
-# put your pytest fixtures here
+import pytest
+from eventyay.base.models import Event, Organizer, Team, User
+from django.utils.timezone import now
+from datetime import timedelta
+
+
+@pytest.fixture
+def organizer():
+    return Organizer.objects.create(name="Test Organizer", slug="test-org")
+
+
+@pytest.fixture
+def event(organizer):
+    return Event.objects.create(
+        organizer=organizer,
+        name="Test Event",
+        slug="test-event",
+        date_from=now(),
+        date_to=now() + timedelta(days=1),
+        currency="USD",
+        live=True,
+        plugins="socialmedia",
+    )
+
+
+@pytest.fixture
+def user():
+    return User.objects.create_user("dummy@dummy.dummy", "dummy")
+
+
+@pytest.fixture
+def logged_in_client(client, user):
+    client.force_login(user)
+    return client
+
+
+@pytest.fixture
+def logged_in_organizer_client(client, user, organizer, event):
+    team = Team.objects.create(
+        organizer=organizer,
+        name="Test Team",
+        can_change_event_settings=True,
+        all_events=True,
+    )
+    team.members.add(user)
+    client.force_login(user)
+    return client

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -87,9 +87,7 @@ def test_socialmedia_settings_view_post(
 
 
 @pytest.mark.django_db
-def test_preview_posts_view(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_preview_posts_view(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     url = reverse(
         "plugins:socialmedia:preview",
@@ -102,9 +100,7 @@ def test_preview_posts_view(
 
 
 @pytest.mark.django_db
-def test_export_csv_view(
-    logged_in_organizer_client, organizer, event, settings
-):
+def test_export_csv_view(logged_in_organizer_client, organizer, event, settings):
     settings.SITE_URL = "https://testserver"
     url = reverse(
         "plugins:socialmedia:export",

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,140 @@
+import json
+import pytest
+from django.urls import reverse
+from django_scopes import scope
+
+
+@pytest.mark.django_db
+def test_socialmedia_settings_view_logged_out(client, organizer, event, settings):
+    settings.SITE_URL = "https://testserver"
+    url = reverse(
+        "plugins:socialmedia:index",
+        kwargs={"organizer": organizer.slug, "event": event.slug},
+    )
+    response = client.get(url)
+    assert response.status_code == 302
+    assert "login" in response.url
+
+
+@pytest.mark.django_db
+def test_socialmedia_settings_view_wrong_organizer(
+    logged_in_client, organizer, event, settings
+):
+    settings.SITE_URL = "https://testserver"
+    url = reverse(
+        "plugins:socialmedia:index",
+        kwargs={"organizer": organizer.slug, "event": event.slug},
+    )
+    response = logged_in_client.get(url)
+    assert response.status_code in [403, 404]
+
+
+@pytest.mark.django_db
+def test_socialmedia_settings_view_correct_organizer(
+    logged_in_organizer_client, organizer, event, settings
+):
+    settings.SITE_URL = "https://testserver"
+    url = reverse(
+        "plugins:socialmedia:index",
+        kwargs={"organizer": organizer.slug, "event": event.slug},
+    )
+    response = logged_in_organizer_client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_socialmedia_settings_view_post(
+    logged_in_organizer_client, organizer, event, settings
+):
+    settings.SITE_URL = "https://testserver"
+    url = reverse(
+        "plugins:socialmedia:index",
+        kwargs={"organizer": organizer.slug, "event": event.slug},
+    )
+
+    response = logged_in_organizer_client.post(
+        url,
+        {
+            "socialmedia_default_hashtags": "#pytest #testing",
+            "socialmedia_cfp_enabled": "on",
+            "socialmedia_cfp_offset": "5",
+            "socialmedia_cfp_template": "CFP Deadline: {cfp_deadline}",
+            "socialmedia_speaker_enabled": "on",
+            "socialmedia_speaker_offset": "3",
+            "socialmedia_speaker_template": "Speaker: {speaker_name}",
+            "socialmedia_session_enabled": "on",
+            "socialmedia_session_offset": "15",
+            "socialmedia_session_template": "Session: {talk_title}",
+            "socialmedia_ticket_enabled": "on",
+            "socialmedia_ticket_offset": "4",
+            "socialmedia_ticket_template": "Ticket: {ticket_name}",
+            "socialmedia_schedule_enabled": "on",
+            "socialmedia_schedule_offset": "1",
+            "socialmedia_schedule_template": "Schedule: {schedule_link}",
+        },
+    )
+
+    assert response.status_code == 302
+
+    with scope(organizer=organizer):
+        event.settings.flush()
+        assert event.settings.get("socialmedia_default_hashtags") == "#pytest #testing"
+        assert event.settings.get("socialmedia_cfp_offset") == "5"
+        assert (
+            event.settings.get("socialmedia_cfp_template")
+            == "CFP Deadline: {cfp_deadline}"
+        )
+
+
+@pytest.mark.django_db
+def test_preview_posts_view(
+    logged_in_organizer_client, organizer, event, settings
+):
+    settings.SITE_URL = "https://testserver"
+    url = reverse(
+        "plugins:socialmedia:preview",
+        kwargs={"organizer": organizer.slug, "event": event.slug},
+    )
+    response = logged_in_organizer_client.get(url)
+    assert response.status_code == 200
+    data = response.json()
+    assert "posts" in data
+
+
+@pytest.mark.django_db
+def test_export_csv_view(
+    logged_in_organizer_client, organizer, event, settings
+):
+    settings.SITE_URL = "https://testserver"
+    url = reverse(
+        "plugins:socialmedia:export",
+        kwargs={"organizer": organizer.slug, "event": event.slug},
+    )
+    payload = {
+        "posts": [
+            {
+                "enabled": True,
+                "post_date": "2026-06-20",
+                "post_time": "12:00",
+                "post_text": "Hello world!",
+                "media_url": "",
+            },
+            {
+                "enabled": False,
+                "post_date": "2026-06-21",
+                "post_time": "13:00",
+                "post_text": "Skipped post",
+                "media_url": "",
+            },
+        ]
+    }
+    response = logged_in_organizer_client.post(
+        url, data=json.dumps(payload), content_type="application/json"
+    )
+    assert response.status_code == 200
+    assert response["Content-Type"] == "text/csv; charset=utf-8"
+    assert "attachment" in response["Content-Disposition"]
+
+    content = response.content.decode("utf-8")
+    assert "Hello world!" in content
+    assert "Skipped post" not in content


### PR DESCRIPTION

#### **Overview**
Sets up PostgreSQL/Redis services in the test pipeline, integrates `pre-commit` hook linters, and introduces a complete integration test suite for the social media plugin views.

#### **Key Changes**
- **Test Workflow Pipeline**: Updated `.github/workflows/tests.yml` to spin up PostgreSQL and Redis services, clone the main `eventyay` repository, sync its dependencies using `uv`, install the plugin in editable mode, and run pytest tests with coverage reporting.
- **Pre-commit Style Checks**: Added a `.pre-commit-config.yaml` using `black` and `ruff`. Adjusted `.github/workflows/style.yml` and `.gitlab-ci.yml` to run checks via `pre-commit`.
- **Database Test Fixtures**: Created `tests/conftest.py` with standard model fixtures for `Event`, `Organizer`, and `User`, along with authenticated client helpers.
- **View Tests**: Added `tests/test_views.py` containing complete integration tests for setting updates, post previews, and CSV exports.

<img width="960" height="166" alt="1" src="https://github.com/user-attachments/assets/977e442e-fec6-4c81-a93f-bed06c651443" />
