### PR TITLE
chore: configure package-data in pyproject.toml to bundle templates, static assets, and translations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,15 @@ repository = "https://github.com/fossasia/eventyay-socialmedia"
 [tool.setuptools]
 include-package-data = true
 
+[tool.setuptools.package-data]
+socialmedia = [
+    "templates/socialmedia/*.html",
+    "static/socialmedia/css/*.css",
+    "static/socialmedia/js/*.js",
+    "locale/*/LC_MESSAGES/*.po",
+    "locale/*/LC_MESSAGES/*.mo",
+]
+
 [tool.setuptools.dynamic]
 version = {attr = "socialmedia.__version__"}
 


### PR DESCRIPTION

### **Description**
When `eventyay-socialmedia` was built and installed (such as on deployment or via `uv sync` from the git repository), non-Python assets—including HTML templates (`socialmedia/templates/`), static CSS/JS files (`socialmedia/static/`), and localization catalogs (`socialmedia/locale/`)—were omitted from the final distribution wheel. This led to `TemplateDoesNotExist` errors at runtime.

#### **Changes**
* Explicitly configured `[tool.setuptools.package-data]` inside `pyproject.toml` to specify the glob paths for non-Python assets.
* This ensures that all templates, static assets, and translation files are correctly packaged and installed into the target environment without relying on a legacy `MANIFEST.in` file.