### PR TITLE
refactor: remove inline event handlers for CSP compliance

### DIFF
--- a/socialmedia/static/socialmedia/js/settings.js
+++ b/socialmedia/static/socialmedia/js/settings.js
@@ -13,7 +13,7 @@
   let activeFilter = "all";
 
   // ---- Load posts from server ----
-  window.loadPosts = function () {
+  function loadPosts() {
     const btn = document.getElementById("btn-regenerate");
     if (!btn) return;
     btn.disabled = true;
@@ -39,7 +39,7 @@
         btn.disabled = false;
         btn.innerHTML = '<i class="fa fa-refresh"></i> Regenerate';
       });
-  };
+  }
 
   // ---- Render table rows ----
   function renderTable(posts, filter) {
@@ -63,8 +63,7 @@
       <tr data-idx="${idx}" data-type="${p.type}" class="${p.enabled ? "" : "row-disabled"}">
         <td>
           <input type="checkbox" class="row-chk" data-idx="${idx}"
-            ${p.enabled ? "checked" : ""}
-            onchange="toggleRow(${idx}, this.checked)">
+            ${p.enabled ? "checked" : ""}>
         </td>
         <td><span class="type-badge type-${p.type}">${escHtml(p.type_label)}</span></td>
         <td class="dt-cell">
@@ -72,15 +71,11 @@
           <div class="dt-time">${escHtml(p.post_time)}</div>
         </td>
         <td class="dt-cell">
-          <input type="time" class="form-control input-sm sm-time-input" value="${escHtml(p.post_time)}"
-            onchange="allPosts[${idx}].post_time = this.value; syncTimeDisplay(${idx}, this.value);">
+          <input type="time" class="form-control input-sm sm-time-input" value="${escHtml(p.post_time)}">
         </td>
         <td class="post-text-cell">
-          <span class="post-text-view" onclick="startEdit(${idx}, this)" data-idx="${idx}">${escHtml(p.post_text)}</span>
-          <textarea class="post-text-edit" data-idx="${idx}"
-            onblur="finishEdit(${idx}, this)"
-            onkeydown="if((event.metaKey||event.ctrlKey)&&event.key==='Enter') this.blur();"
-          >${escHtml(p.post_text)}</textarea>
+          <span class="post-text-view" data-idx="${idx}">${escHtml(p.post_text)}</span>
+          <textarea class="post-text-edit" data-idx="${idx}">${escHtml(p.post_text)}</textarea>
           <span class="edit-hint">${escHtml(TRANS_CLICK_TO_EDIT)}</span>
         </td>
       </tr>`;
@@ -101,34 +96,35 @@
   }
 
   // ---- Inline editing ----
-  window.startEdit = function (idx, span) {
+  function startEdit(idx, span) {
     const ta = span.nextElementSibling;
     span.classList.add("editing");
     ta.classList.add("editing");
     ta.style.display = "block";
     ta.focus();
     ta.setSelectionRange(ta.value.length, ta.value.length);
-  };
+  }
 
-  window.finishEdit = function (idx, ta) {
+  // Focusout / blur
+  function finishEdit(idx, ta) {
     allPosts[idx].post_text = ta.value;
     const span = ta.previousElementSibling;
     span.textContent = ta.value;
     span.classList.remove("editing");
     ta.classList.remove("editing");
     ta.style.display = "none";
-  };
+  }
 
   // ---- Toggle row ----
-  window.toggleRow = function (idx, enabled) {
+  function toggleRow(idx, enabled) {
     allPosts[idx].enabled = enabled;
     const row = document.querySelector(`tr[data-idx="${idx}"]`);
     if (row) row.classList.toggle("row-disabled", !enabled);
     updateSelectedCount();
-  };
+  }
 
   // ---- Select all / none ----
-  window.selectAll = function (val) {
+  function selectAll(val) {
     allPosts.forEach((p, i) => { p.enabled = val; });
     document.querySelectorAll(".row-chk").forEach(chk => {
       const idx = parseInt(chk.dataset.idx);
@@ -142,15 +138,15 @@
       chkAll.indeterminate = false;
     }
     updateSelectedCount();
-  };
+  }
 
   // ---- Filter ----
-  window.filterPosts = function (type, btn) {
+  function filterPosts(type, btn) {
     activeFilter = type;
     document.querySelectorAll(".sm-filter-btn").forEach(b => b.classList.remove("active"));
     btn.classList.add("active");
     renderTable(allPosts, type);
-  };
+  }
 
   // ---- Update counters ----
   function updateCounts() {
@@ -181,7 +177,7 @@
   }
 
   // ---- Export CSV ----
-  window.exportCSV = function () {
+  function exportCSV() {
     const selected = allPosts.filter(p => p.enabled);
     if (!selected.length) {
       alert(TRANS_SELECT_AT_LEAST_ONE);
@@ -212,17 +208,17 @@
         URL.revokeObjectURL(url);
       })
       .catch(err => alert("Export error: " + err.message));
-  };
+  }
 
   // ---- Advanced settings toggle ----
-  window.toggleAdv = function () {
+  function toggleAdv() {
     const body = document.getElementById("adv-body");
     const hdr  = document.getElementById("adv-toggle");
     if (body && hdr) {
       const open = body.classList.toggle("open");
       hdr.classList.toggle("open", open);
     }
-  };
+  }
 
   // ---- Skeleton helper ----
   function showSkeleton() {
@@ -247,6 +243,98 @@
       .replace(/"/g, "&quot;");
   }
 
-  // Auto-load on page ready
-  document.addEventListener("DOMContentLoaded", loadPosts);
+  // ---- Event Bindings ----
+  function bindEvents() {
+    const btnRegen = document.getElementById("btn-regenerate");
+    if (btnRegen) btnRegen.addEventListener("click", loadPosts);
+
+    const btnSaveRegen = document.getElementById("btn-save-regenerate");
+    if (btnSaveRegen) btnSaveRegen.addEventListener("click", loadPosts);
+
+    const filterPills = document.getElementById("filter-pills");
+    if (filterPills) {
+      filterPills.addEventListener("click", function (e) {
+        const btn = e.target.closest(".sm-filter-btn");
+        if (btn) {
+          filterPosts(btn.dataset.type, btn);
+        }
+      });
+    }
+
+    const btnSelectAll = document.getElementById("btn-select-all");
+    if (btnSelectAll) {
+      btnSelectAll.addEventListener("click", () => selectAll(true));
+    }
+
+    const btnDeselectAll = document.getElementById("btn-deselect-all");
+    if (btnDeselectAll) {
+      btnDeselectAll.addEventListener("click", () => selectAll(false));
+    }
+
+    const chkAll = document.getElementById("chk-all");
+    if (chkAll) {
+      chkAll.addEventListener("change", function () {
+        selectAll(this.checked);
+      });
+    }
+
+    const btnExport = document.getElementById("btn-export");
+    if (btnExport) {
+      btnExport.addEventListener("click", exportCSV);
+    }
+
+    const advToggle = document.getElementById("adv-toggle");
+    if (advToggle) {
+      advToggle.addEventListener("click", toggleAdv);
+    }
+
+    // Attach tbody event delegation
+    const tbody = document.getElementById("posts-tbody");
+    if (tbody) {
+      tbody.addEventListener("click", function (e) {
+        if (e.target.classList.contains("post-text-view")) {
+          const idx = parseInt(e.target.dataset.idx);
+          startEdit(idx, e.target);
+        }
+      });
+
+      tbody.addEventListener("change", function (e) {
+        if (e.target.classList.contains("row-chk")) {
+          const idx = parseInt(e.target.dataset.idx);
+          toggleRow(idx, e.target.checked);
+        } else if (e.target.classList.contains("sm-time-input")) {
+          const row = e.target.closest("tr");
+          const idx = parseInt(row.dataset.idx);
+          allPosts[idx].post_time = e.target.value;
+          syncTimeDisplay(idx, e.target.value);
+        }
+      });
+
+      tbody.addEventListener("keydown", function (e) {
+        if (e.target.classList.contains("post-text-edit")) {
+          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+            e.target.blur();
+          }
+        }
+      });
+
+      tbody.addEventListener("focusout", function (e) {
+        if (e.target.classList.contains("post-text-edit")) {
+          const idx = parseInt(e.target.dataset.idx);
+          finishEdit(idx, e.target);
+        }
+      });
+    }
+  }
+
+  // Auto-load and bind on page ready
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => {
+      bindEvents();
+      loadPosts();
+    });
+  } else {
+    bindEvents();
+    loadPosts();
+  }
 })();

--- a/socialmedia/static/socialmedia/js/settings.js
+++ b/socialmedia/static/socialmedia/js/settings.js
@@ -59,13 +59,14 @@
 
     tbody.innerHTML = visible.map((p, i) => {
       const idx = allPosts.indexOf(p);
+      const safeType = escHtml(p.type);
       return `
-      <tr data-idx="${idx}" data-type="${p.type}" class="${p.enabled ? "" : "row-disabled"}">
+      <tr data-idx="${idx}" data-type="${safeType}" class="${p.enabled ? "" : "row-disabled"}">
         <td>
           <input type="checkbox" class="row-chk" data-idx="${idx}"
             ${p.enabled ? "checked" : ""}>
         </td>
-        <td><span class="type-badge type-${p.type}">${escHtml(p.type_label)}</span></td>
+        <td><span class="type-badge type-${safeType}">${escHtml(p.type_label)}</span></td>
         <td class="dt-cell">
           <div class="dt-date">${escHtml(p.post_date)}</div>
           <div class="dt-time">${escHtml(p.post_time)}</div>

--- a/socialmedia/templates/socialmedia/settings.html
+++ b/socialmedia/templates/socialmedia/settings.html
@@ -16,39 +16,39 @@
       {% trans "Social Media Posts" %}
       <small>{{ event.name }}</small>
     </h1>
-    <button id="btn-regenerate" class="btn btn-default" onclick="loadPosts()">
+    <button id="btn-regenerate" class="btn btn-default">
       <i class="fa fa-refresh"></i> {% trans "Regenerate" %}
     </button>
   </div>
 
   <!-- Filter pills -->
   <div class="sm-filters" id="filter-pills">
-    <button class="sm-filter-btn active" data-type="all" onclick="filterPosts('all', this)">
+    <button class="sm-filter-btn active" data-type="all">
       {% trans "All" %} <span class="count" id="cnt-all">0</span>
     </button>
-    <button class="sm-filter-btn" data-type="cfp" onclick="filterPosts('cfp', this)">
+    <button class="sm-filter-btn" data-type="cfp">
       {% trans "CFP" %} <span class="count" id="cnt-cfp">0</span>
     </button>
-    <button class="sm-filter-btn" data-type="speaker" onclick="filterPosts('speaker', this)">
+    <button class="sm-filter-btn" data-type="speaker">
       {% trans "Speakers" %} <span class="count" id="cnt-speaker">0</span>
     </button>
-    <button class="sm-filter-btn" data-type="session" onclick="filterPosts('session', this)">
+    <button class="sm-filter-btn" data-type="session">
       {% trans "Sessions" %} <span class="count" id="cnt-session">0</span>
     </button>
-    <button class="sm-filter-btn" data-type="ticket" onclick="filterPosts('ticket', this)">
+    <button class="sm-filter-btn" data-type="ticket">
       {% trans "Tickets" %} <span class="count" id="cnt-ticket">0</span>
     </button>
-    <button class="sm-filter-btn" data-type="schedule" onclick="filterPosts('schedule', this)">
+    <button class="sm-filter-btn" data-type="schedule">
       {% trans "Schedule" %} <span class="count" id="cnt-schedule">0</span>
     </button>
   </div>
 
   <!-- Action bar -->
   <div class="sm-actions">
-    <button class="btn btn-default btn-sm" onclick="selectAll(true)">
+    <button id="btn-select-all" class="btn btn-default btn-sm">
       <i class="fa fa-check-square-o"></i> {% trans "Select All" %}
     </button>
-    <button class="btn btn-default btn-sm" onclick="selectAll(false)">
+    <button id="btn-deselect-all" class="btn btn-default btn-sm">
       <i class="fa fa-square-o"></i> {% trans "Deselect All" %}
     </button>
     <span class="sm-count" id="selected-count">–</span>
@@ -59,7 +59,7 @@
     <table class="sm-table">
       <thead>
         <tr>
-          <th><input type="checkbox" id="chk-all" onchange="selectAll(this.checked)" title="{% trans 'Toggle all' %}"></th>
+          <th><input type="checkbox" id="chk-all" title="{% trans 'Toggle all' %}"></th>
           <th>{% trans "Type" %}</th>
           <th>{% trans "Date" %}</th>
           <th>{% trans "Time" %}</th>
@@ -84,7 +84,7 @@
   <!-- Sticky export bar -->
   <div class="export-bar">
     <span class="selected-count" id="export-count">0 {% trans "posts selected" %}</span>
-    <button class="btn btn-primary btn-export" onclick="exportCSV()">
+    <button id="btn-export" class="btn btn-primary btn-export">
       <i class="fa fa-download"></i> {% trans "Export CSV" %}
     </button>
   </div>
@@ -93,7 +93,7 @@
        Advanced Settings (collapsible)
        ================================================================ -->
   <div class="adv-section">
-    <button class="adv-header" id="adv-toggle" onclick="toggleAdv()">
+    <button class="adv-header" type="button" id="adv-toggle">
       <i class="fa fa-cog"></i>
       {% trans "Advanced Settings" %}
       <span style="font-size:12px;font-weight:400;color:#aaa;">
@@ -177,7 +177,7 @@
           <button type="submit" class="btn btn-primary">
             <i class="fa fa-save"></i> {% trans "Save Settings" %}
           </button>
-          <button type="button" class="btn btn-default" onclick="loadPosts()">
+          <button type="button" id="btn-save-regenerate" class="btn btn-default">
             <i class="fa fa-refresh"></i> {% trans "Save & Regenerate Preview" %}
           </button>
         </div>


### PR DESCRIPTION
In deployment, inline JavaScript execution is blocked by the Content Security Policy (CSP). The settings page used direct `onclick` and `onchange` attributes in the HTML template and dynamically rendered strings (e.g. for `#adv-toggle`, `.sm-filter-btn`, checkboxes, etc.). This caused CSP violations and blocked user interactions like toggling the "Advanced Settings" section.

#### **Updates**
* Removed all inline event handler attributes (`onclick`, `onchange`, `onblur`, `onkeydown`) from [settings.html](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/templates/socialmedia/settings.html) and [settings.js](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/static/socialmedia/js/settings.js).
* Attached event listeners programmatically in [settings.js](file:///home/saalim/OSS/eventyay-socialmedia/socialmedia/static/socialmedia/js/settings.js) using standard event listeners for static page elements.
* Implemented **event delegation** on `#posts-tbody` to safely handle click, change, keydown, and blur events on dynamically generated elements.

These changes eliminate all inline handlers, fully resolving the CSP violations on deployment.

## Summary by Sourcery

Refactor the social media settings page to remove inline JavaScript handlers and rely on script-based event binding for CSP compliance.

Enhancements:
- Bind all settings page interactions via JavaScript event listeners instead of inline HTML handlers, including regeneration, filtering, bulk selection, CSV export, and advanced settings toggling.
- Introduce delegated event handling on the posts table body to manage checkbox toggles, time edits, and inline text editing for dynamically rendered rows.
- Scope previously global helper functions to the settings script and initialize bindings together with post loading on document readiness.