### PR TITLE
feat: polish social media preview UI and implement bulk scheduling presets

### DIFF
--- a/socialmedia/export.py
+++ b/socialmedia/export.py
@@ -136,6 +136,8 @@ def build_posts(event, request=None):
                 "reference_date": ref_date,
                 "original_post_date": trigger.strftime("%Y-%m-%d"),
                 "original_post_time": trigger.strftime("%H:%M"),
+                "event_schedule_display": "N/A",
+                "is_schedule_associated": False,
             }
         )
 
@@ -166,6 +168,8 @@ def build_posts(event, request=None):
                 "reference_date": ref_date,
                 "original_post_date": trigger.strftime("%Y-%m-%d"),
                 "original_post_time": trigger.strftime("%H:%M"),
+                "event_schedule_display": "N/A",
+                "is_schedule_associated": False,
             }
         )
 
@@ -209,6 +213,8 @@ def build_posts(event, request=None):
                     "reference_date": ref_date,
                     "original_post_date": trigger.strftime("%Y-%m-%d"),
                     "original_post_time": trigger.strftime("%H:%M"),
+                    "event_schedule_display": "N/A",
+                    "is_schedule_associated": False,
                 }
             )
 
@@ -221,30 +227,40 @@ def build_posts(event, request=None):
     )
 
     if speaker_enabled or session_enabled:
-        schedule = getattr(event, "current_schedule", None) or getattr(
-            event, "wip_schedule", None
-        )
-        if schedule:
-            filters = {"submission__isnull": False}
+        submissions_mgr = getattr(event, "submissions", None)
+        if submissions_mgr:
+            filters = {}
             if SubmissionStates:
-                filters["submission__state__in"] = [
-                    SubmissionStates.CONFIRMED,
-                    SubmissionStates.ACCEPTED,
-                ]
-            talks = list(
-                schedule.talks.filter(**filters)
-                .select_related("submission", "room")
-                .prefetch_related("submission__speakers")
+                filters["state"] = SubmissionStates.CONFIRMED
+            confirmed_subs = list(
+                submissions_mgr.filter(**filters).prefetch_related("speakers")
             )
+
+            schedule = getattr(event, "current_schedule", None) or getattr(
+                event, "wip_schedule", None
+            )
+            talks_by_sub = {}
+            if schedule:
+                talk_qs = schedule.talks.filter(
+                    submission__in=confirmed_subs
+                ).select_related("submission", "room")
+                for talk in talk_qs:
+                    talks_by_sub[talk.submission_id] = talk
 
             spk_offset = _get_offset(event, "speaker", 3)
             sess_offset = _get_offset(event, "session", 30)  # minutes
 
             seen_speakers = set()
 
-            for talk in talks:
-                sub = talk.submission
-                talk_start = talk.start
+            for sub in confirmed_subs:
+                talk = talks_by_sub.get(sub.pk)
+                talk_start = talk.start if talk else None
+
+                if talk_start:
+                    local_start = localize(talk_start, event)
+                    sched_display = local_start.strftime("%b %d, %Y %H:%M")
+                else:
+                    sched_display = "Unscheduled"
 
                 # Speaker post (one per unique speaker)
                 if speaker_enabled:
@@ -277,9 +293,10 @@ def build_posts(event, request=None):
                                 if base_time
                                 else None
                             )
+                            talk_pk = talk.pk if talk else sub.pk
                             posts.append(
                                 {
-                                    "id": f"speaker_{speaker.pk}_{talk.pk}",
+                                    "id": f"speaker_{speaker.pk}_{talk_pk}",
                                     "type": "speaker",
                                     "type_label": TYPE_LABELS["speaker"],
                                     "post_date": trigger.strftime("%Y-%m-%d"),
@@ -289,52 +306,66 @@ def build_posts(event, request=None):
                                     "reference_date": ref_date,
                                     "original_post_date": trigger.strftime("%Y-%m-%d"),
                                     "original_post_time": trigger.strftime("%H:%M"),
+                                    "event_schedule_display": sched_display,
+                                    "is_schedule_associated": True,
                                 }
                             )
 
                 # Session post
-                if session_enabled and talk_start:
-                    trigger = localize(
-                        talk_start - timedelta(minutes=sess_offset), event
-                    )
-                    local_start = localize(talk_start, event)
-                    names = ", ".join(s.get_display_name() for s in sub.speakers.all())
-                    room = talk.room.name if talk.room else "TBA"
-                    if sub.code:
-                        talk_url = event_absolute_url(
-                            f"{event.urls.base}talk/{sub.code}/", request
+                if session_enabled:
+                    base_time = talk_start or getattr(event, "date_from", None)
+                    if base_time:
+                        if talk_start:
+                            trigger = localize(
+                                talk_start - timedelta(minutes=sess_offset), event
+                            )
+                            local_start = localize(talk_start, event)
+                            talk_time_str = local_start.strftime("%H:%M")
+                        else:
+                            trigger = localize(base_time - timedelta(days=1), event)
+                            talk_time_str = "TBA"
+                        names = ", ".join(
+                            s.get_display_name() for s in sub.speakers.all()
                         )
-                    else:
-                        talk_url = event_link
-                    text = safe_format(
-                        _get_template(event, "session"),
-                        event_name=str(event.name),
-                        talk_title=sub.title,
-                        talk_room=room,
-                        talk_start_time=local_start.strftime("%H:%M"),
-                        speaker_names=names,
-                        talk_link=talk_url,
-                        hashtags=hashtags,
-                    )
-                    ref_date = (
-                        localize(talk_start, event).strftime("%Y-%m-%d")
-                        if talk_start
-                        else None
-                    )
-                    posts.append(
-                        {
-                            "id": f"session_{talk.pk}",
-                            "type": "session",
-                            "type_label": TYPE_LABELS["session"],
-                            "post_date": trigger.strftime("%Y-%m-%d"),
-                            "post_time": trigger.strftime("%H:%M"),
-                            "post_text": text,
-                            "default_text": text,
-                            "reference_date": ref_date,
-                            "original_post_date": trigger.strftime("%Y-%m-%d"),
-                            "original_post_time": trigger.strftime("%H:%M"),
-                        }
-                    )
+                        room = talk.room.name if (talk and talk.room) else "TBA"
+                        if sub.code:
+                            talk_url = event_absolute_url(
+                                f"{event.urls.base}talk/{sub.code}/", request
+                            )
+                        else:
+                            talk_url = event_link
+                        text = safe_format(
+                            _get_template(event, "session"),
+                            event_name=str(event.name),
+                            talk_title=sub.title,
+                            talk_room=room,
+                            talk_start_time=talk_time_str,
+                            speaker_names=names,
+                            talk_link=talk_url,
+                            hashtags=hashtags,
+                        )
+                        ref_date = (
+                            localize(base_time, event).strftime("%Y-%m-%d")
+                            if base_time
+                            else None
+                        )
+                        talk_pk = talk.pk if talk else sub.pk
+                        posts.append(
+                            {
+                                "id": f"session_{talk_pk}",
+                                "type": "session",
+                                "type_label": TYPE_LABELS["session"],
+                                "post_date": trigger.strftime("%Y-%m-%d"),
+                                "post_time": trigger.strftime("%H:%M"),
+                                "post_text": text,
+                                "default_text": text,
+                                "reference_date": ref_date,
+                                "original_post_date": trigger.strftime("%Y-%m-%d"),
+                                "original_post_time": trigger.strftime("%H:%M"),
+                                "event_schedule_display": sched_display,
+                                "is_schedule_associated": True,
+                            }
+                        )
 
     # Sort chronologically
     posts.sort(key=lambda p: (p["post_date"], p["post_time"]))

--- a/socialmedia/export.py
+++ b/socialmedia/export.py
@@ -88,12 +88,21 @@ def _get_template(event, key):
 
 
 def _get_offset(event, key, default):
-    raw = event.settings.get(f"socialmedia_{key}_offset", as_type=str)
-    if raw is None:
+    raw = event.settings.get(f"socialmedia_{key}_offset")
+    if raw is None or raw == "":
         return default
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, float):
+        return int(raw)
+
+    val_str = str(raw).strip()
+    if not val_str:
+        return default
+
     # Handle comma-separated values saved by multi-offset forms
     # (e.g. "14, 7") — take only the first entry for single-offset mode.
-    first = raw.split(",")[0].strip()
+    first = val_str.split(",")[0].strip()
     try:
         return int(first)
     except (ValueError, TypeError):
@@ -245,9 +254,7 @@ def build_posts(event, request=None):
                 submissions_mgr.filter(**filters).prefetch_related("speakers")
             )
 
-            schedule = getattr(event, "current_schedule", None) or getattr(
-                event, "wip_schedule", None
-            )
+            schedule = getattr(event, "current_schedule", None)
             talks_by_sub = {}
             if schedule:
                 talk_qs = schedule.talks.filter(

--- a/socialmedia/export.py
+++ b/socialmedia/export.py
@@ -88,12 +88,12 @@ def _get_template(event, key):
 
 
 def _get_offset(event, key, default):
-    raw = event.settings.get(f"socialmedia_{key}_offset", default)
+    raw = event.settings.get(f"socialmedia_{key}_offset", as_type=str)
     if raw is None:
         return default
     # Handle comma-separated values saved by multi-offset forms
     # (e.g. "14, 7") — take only the first entry for single-offset mode.
-    first = str(raw).split(",")[0].strip()
+    first = raw.split(",")[0].strip()
     try:
         return int(first)
     except (ValueError, TypeError):
@@ -263,14 +263,13 @@ def build_posts(event, request=None):
 
             for sub in confirmed_subs:
                 talk = talks_by_sub.get(sub.pk)
-                if not talk or not talk.start:
-                    # Skip confirmed-but-unscheduled sessions — no valid
-                    # trigger time can be derived yet.
-                    continue
-                talk_start = talk.start
+                talk_start = talk.start if talk else None
 
-                local_start = localize(talk_start, event)
-                sched_display = local_start.strftime("%b %d, %Y %H:%M")
+                if talk_start:
+                    local_start = localize(talk_start, event)
+                    sched_display = local_start.strftime("%b %d, %Y %H:%M")
+                else:
+                    sched_display = "Unscheduled"
 
                 # Speaker post (one per unique speaker)
                 if speaker_enabled:

--- a/socialmedia/export.py
+++ b/socialmedia/export.py
@@ -88,7 +88,16 @@ def _get_template(event, key):
 
 
 def _get_offset(event, key, default):
-    return event.settings.get(f"socialmedia_{key}_offset", default, as_type=int)
+    raw = event.settings.get(f"socialmedia_{key}_offset", default)
+    if raw is None:
+        return default
+    # Handle comma-separated values saved by multi-offset forms
+    # (e.g. "14, 7") — take only the first entry for single-offset mode.
+    first = str(raw).split(",")[0].strip()
+    try:
+        return int(first)
+    except (ValueError, TypeError):
+        return default
 
 
 # ---------------------------------------------------------------------------
@@ -254,13 +263,14 @@ def build_posts(event, request=None):
 
             for sub in confirmed_subs:
                 talk = talks_by_sub.get(sub.pk)
-                talk_start = talk.start if talk else None
+                if not talk or not talk.start:
+                    # Skip confirmed-but-unscheduled sessions — no valid
+                    # trigger time can be derived yet.
+                    continue
+                talk_start = talk.start
 
-                if talk_start:
-                    local_start = localize(talk_start, event)
-                    sched_display = local_start.strftime("%b %d, %Y %H:%M")
-                else:
-                    sched_display = "Unscheduled"
+                local_start = localize(talk_start, event)
+                sched_display = local_start.strftime("%b %d, %Y %H:%M")
 
                 # Speaker post (one per unique speaker)
                 if speaker_enabled:
@@ -293,10 +303,9 @@ def build_posts(event, request=None):
                                 if base_time
                                 else None
                             )
-                            talk_pk = talk.pk if talk else sub.pk
                             posts.append(
                                 {
-                                    "id": f"speaker_{speaker.pk}_{talk_pk}",
+                                    "id": f"speaker_{speaker.pk}",
                                     "type": "speaker",
                                     "type_label": TYPE_LABELS["speaker"],
                                     "post_date": trigger.strftime("%Y-%m-%d"),

--- a/socialmedia/export.py
+++ b/socialmedia/export.py
@@ -123,13 +123,19 @@ def build_posts(event, request=None):
             cfp_link=cfp_url,
             hashtags=hashtags,
         )
+        ref_date = localize(cfp.deadline, event).strftime("%Y-%m-%d")
         posts.append(
             {
+                "id": "cfp",
                 "type": "cfp",
                 "type_label": TYPE_LABELS["cfp"],
                 "post_date": trigger.strftime("%Y-%m-%d"),
                 "post_time": trigger.strftime("%H:%M"),
                 "post_text": text,
+                "default_text": text,
+                "reference_date": ref_date,
+                "original_post_date": trigger.strftime("%Y-%m-%d"),
+                "original_post_time": trigger.strftime("%H:%M"),
             }
         )
 
@@ -147,13 +153,19 @@ def build_posts(event, request=None):
             schedule_link=schedule_url,
             hashtags=hashtags,
         )
+        ref_date = localize(event.date_from, event).strftime("%Y-%m-%d")
         posts.append(
             {
+                "id": "schedule",
                 "type": "schedule",
                 "type_label": TYPE_LABELS["schedule"],
                 "post_date": trigger.strftime("%Y-%m-%d"),
                 "post_time": trigger.strftime("%H:%M"),
                 "post_text": text,
+                "default_text": text,
+                "reference_date": ref_date,
+                "original_post_date": trigger.strftime("%Y-%m-%d"),
+                "original_post_time": trigger.strftime("%H:%M"),
             }
         )
 
@@ -184,13 +196,19 @@ def build_posts(event, request=None):
                 ticket_link=event_link,
                 hashtags=hashtags,
             )
+            ref_date = localize(event.date_from, event).strftime("%Y-%m-%d")
             posts.append(
                 {
+                    "id": f"ticket_{ticket.pk}",
                     "type": "ticket",
                     "type_label": TYPE_LABELS["ticket"],
                     "post_date": trigger.strftime("%Y-%m-%d"),
                     "post_time": trigger.strftime("%H:%M"),
                     "post_text": text,
+                    "default_text": text,
+                    "reference_date": ref_date,
+                    "original_post_date": trigger.strftime("%Y-%m-%d"),
+                    "original_post_time": trigger.strftime("%H:%M"),
                 }
             )
 
@@ -254,13 +272,23 @@ def build_posts(event, request=None):
                                 talk_title=sub.title,
                                 hashtags=hashtags,
                             )
+                            ref_date = (
+                                localize(base_time, event).strftime("%Y-%m-%d")
+                                if base_time
+                                else None
+                            )
                             posts.append(
                                 {
+                                    "id": f"speaker_{speaker.pk}_{talk.pk}",
                                     "type": "speaker",
                                     "type_label": TYPE_LABELS["speaker"],
                                     "post_date": trigger.strftime("%Y-%m-%d"),
                                     "post_time": trigger.strftime("%H:%M"),
                                     "post_text": text,
+                                    "default_text": text,
+                                    "reference_date": ref_date,
+                                    "original_post_date": trigger.strftime("%Y-%m-%d"),
+                                    "original_post_time": trigger.strftime("%H:%M"),
                                 }
                             )
 
@@ -288,13 +316,23 @@ def build_posts(event, request=None):
                         talk_link=talk_url,
                         hashtags=hashtags,
                     )
+                    ref_date = (
+                        localize(talk_start, event).strftime("%Y-%m-%d")
+                        if talk_start
+                        else None
+                    )
                     posts.append(
                         {
+                            "id": f"session_{talk.pk}",
                             "type": "session",
                             "type_label": TYPE_LABELS["session"],
                             "post_date": trigger.strftime("%Y-%m-%d"),
                             "post_time": trigger.strftime("%H:%M"),
                             "post_text": text,
+                            "default_text": text,
+                            "reference_date": ref_date,
+                            "original_post_date": trigger.strftime("%Y-%m-%d"),
+                            "original_post_time": trigger.strftime("%H:%M"),
                         }
                     )
 

--- a/socialmedia/static/socialmedia/css/settings.css
+++ b/socialmedia/static/socialmedia/css/settings.css
@@ -528,7 +528,7 @@
 
 .post-schedule-cell-wrap .form-control.sm-date-input,
 .post-schedule-cell-wrap .form-control.sm-time-input {
-  width: 100% !important;
+  width: 100%;
   height: 28px;
   font-size: 12px;
   border-radius: 4px;
@@ -600,4 +600,55 @@
   background: #f1f3f4;
   color: #70757a;
   border: 1px solid #dadce0;
+}
+
+/* ---- Table header tooltip helpers ---- */
+.help-tooltip {
+  cursor: help;
+  border-bottom: 1px dotted #ccc;
+}
+
+.th-timezone {
+  font-size: 10px;
+  font-weight: normal;
+  color: #888;
+  text-transform: none;
+  margin-top: 2px;
+}
+
+.th-hint {
+  font-weight: 400;
+  color: #aaa;
+  font-size: 11px;
+}
+
+/* ---- Toast notifications ---- */
+.sm-toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 9999;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  padding: 12px 20px;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 220px;
+}
+
+/* ---- Char count row below post text editor ---- */
+.char-count-wrap {
+  font-size: 11px;
+  color: #888;
+  margin-top: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+/* ---- Validation alert banner ---- */
+.sm-validation-alert {
+  margin-bottom: 12px;
 }

--- a/socialmedia/static/socialmedia/css/settings.css
+++ b/socialmedia/static/socialmedia/css/settings.css
@@ -90,6 +90,9 @@
   border: 1px solid #e4e4e4;
   border-radius: 8px;
   overflow-x: auto;
+  overflow-y: auto;
+  max-height: 500px;
+  position: relative;
   box-shadow: 0 1px 4px rgba(0, 0, 0, .06);
 }
 
@@ -99,6 +102,9 @@
 }
 
 .sm-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 10;
   background: #f5f6f8;
   font-size: 12px;
   font-weight: 600;
@@ -106,7 +112,7 @@
   letter-spacing: .04em;
   color: #777;
   padding: 10px 12px;
-  border-bottom: 1px solid #e4e4e4;
+  border-bottom: 1.5px solid #e4e4e4;
   text-align: left;
   white-space: nowrap;
 }
@@ -400,6 +406,84 @@
 .form-control.sm-time-input {
   width: 110px;
   display: inline-block;
+}
+
+.bulk-schedule-wrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.bulk-schedule-select {
+  width: auto;
+  min-width: 150px;
+}
+
+.bulk-schedule-custom-inputs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* Date input styling */
+.form-control.sm-date-input {
+  width: 135px;
+  display: inline-block;
+}
+
+/* Reference date */
+.dt-ref-date {
+  font-size: 11px;
+  color: #888;
+  margin-top: 3px;
+}
+
+/* Modified state styling */
+.sm-table tbody input.is-modified,
+.sm-table tbody textarea.is-modified {
+  background-color: #fff9e6 !important;
+  border-color: #f0a818 !important;
+  box-shadow: 0 0 2px rgba(240, 168, 24, 0.4);
+}
+
+.is-modified-label {
+  font-size: 10px;
+  color: #c08000;
+  margin-top: 2px;
+  font-weight: bold;
+}
+
+/* Validation warning styles */
+.sm-table tbody input.has-warning,
+.sm-table tbody textarea.has-warning {
+  border-color: #d9534f !important;
+}
+
+.validation-warning-badge {
+  color: #d9534f;
+  font-size: 11px;
+  margin-top: 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: 600;
+}
+
+/* Revert text link */
+.btn-revert-text {
+  color: #0077cc;
+  font-size: 11px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  display: inline-block;
+  margin-top: 4px;
+}
+
+.btn-revert-text:hover {
+  text-decoration: underline;
+  color: #005599;
 }
 
 /* ---- Responsive Layout ---- */

--- a/socialmedia/static/socialmedia/css/settings.css
+++ b/socialmedia/static/socialmedia/css/settings.css
@@ -492,23 +492,112 @@
     flex-direction: column;
     align-items: stretch;
   }
+
   .sm-toolbar h1 {
     margin-bottom: 10px;
   }
+
   .sm-filters {
     gap: 4px;
   }
+
   .sm-filter-btn {
     padding: 4px 10px;
     font-size: 12px;
   }
+
   .export-bar {
     flex-direction: column;
     align-items: stretch;
     gap: 10px;
   }
+
   .export-bar .btn-export {
     width: 100%;
     margin-left: 0;
   }
+}
+
+/* ---- Post Schedule Cell Styling ---- */
+.post-schedule-cell-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 130px;
+}
+
+.post-schedule-cell-wrap .form-control.sm-date-input,
+.post-schedule-cell-wrap .form-control.sm-time-input {
+  width: 100% !important;
+  height: 28px;
+  font-size: 12px;
+  border-radius: 4px;
+  padding: 2px 6px;
+  box-shadow: none;
+  border: 1px solid #ccc;
+  transition: border-color .15s ease-in-out;
+}
+
+.post-schedule-cell-wrap .form-control:focus {
+  border-color: #0077cc;
+}
+
+/* ---- Event Schedule Badges & Stacked Box ---- */
+.event-schedule-cell {
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.sched-box {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 11.5px;
+  font-weight: 600;
+  line-height: 1.3;
+  width: max-content;
+}
+
+.sched-date-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: 600;
+}
+
+.sched-time-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  opacity: 0.9;
+}
+
+.sched-badge {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 11.5px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.sched-active {
+  background: #e6f4ea;
+  color: #137333;
+  border: 1px solid #ceead6;
+}
+
+.sched-unscheduled {
+  background: #fef7e0;
+  color: #b06000;
+  border: 1px solid #feefc3;
+}
+
+.sched-na {
+  background: #f1f3f4;
+  color: #70757a;
+  border: 1px solid #dadce0;
 }

--- a/socialmedia/static/socialmedia/js/settings.js
+++ b/socialmedia/static/socialmedia/js/settings.js
@@ -1,116 +1,237 @@
 (function () {
-  const configEl = document.getElementById("socialmedia-config");
-  if (!configEl) return;
-  const config = JSON.parse(configEl.textContent);
+  // ---- Config module ----
+  const Config = (function () {
+    const configEl = document.getElementById("socialmedia-config");
+    if (!configEl) return null;
+    const config = JSON.parse(configEl.textContent);
 
-  const PREVIEW_URL = config.previewUrl;
-  const EXPORT_URL  = config.exportUrl;
-  const CSRF_TOKEN  = config.csrfToken;
-  const TRANS_CLICK_TO_EDIT = config.transClickToEdit || "Click to edit · Ctrl+Enter to save";
-  const TRANS_SELECT_AT_LEAST_ONE = config.transSelectAtLeastOne || "Please select at least one post to export.";
+    return {
+      PREVIEW_URL: config.previewUrl,
+      EXPORT_URL: config.exportUrl,
+      CSRF_TOKEN: config.csrfToken,
+      TRANS_CLICK_TO_EDIT: config.transClickToEdit || "Click to edit · Ctrl+Enter to save",
+      TRANS_SELECT_AT_LEAST_ONE: config.transSelectAtLeastOne || "Please select at least one post to export.",
+    };
+  })();
 
-  let allPosts = [];   // full data from server
-  let activeFilter = "all";
+  if (!Config) return;
 
-  // ---- Helper for date calculation ----
-  function addDays(dateStr, days) {
-    const parts = dateStr.split('-');
-    const date = new Date(Date.UTC(parseInt(parts[0]), parseInt(parts[1]) - 1, parseInt(parts[2])));
-    date.setUTCDate(date.getUTCDate() + days);
-    return date.toISOString().split('T')[0];
-  }
-
-  // ---- Toast notifications ----
-  function showToast(msg, type = "success") {
-    const toast = document.createElement("div");
-    toast.className = `sm-toast alert alert-${type === "success" ? "success" : "warning"}`;
-
-    const icon = document.createElement("i");
-    icon.className = `fa ${type === "success" ? "fa-check-circle" : "fa-warning"}`;
-    toast.appendChild(icon);
-    toast.appendChild(document.createTextNode(msg));
-
-    document.body.appendChild(toast);
-    setTimeout(() => {
-      toast.style.transition = "opacity 0.5s ease";
-      toast.style.opacity = "0";
-      setTimeout(() => toast.remove(), 500);
-    }, 3000);
-  }
-
-  // ---- Load posts from server ----
-  function loadPosts() {
-    const btn = document.getElementById("btn-regenerate");
-    if (!btn) return;
-    btn.disabled = true;
-    btn.innerHTML = '<i class="fa fa-refresh"></i> Loading…';
-    showSkeleton();
-
-    fetch(PREVIEW_URL, { headers: { "X-Requested-With": "XMLHttpRequest" } })
-      .then(r => r.json())
-      .then(data => {
-        const incoming = data.posts || [];
-        const oldMap = {};
-        allPosts.forEach(p => {
-          if (p.id) {
-            oldMap[p.id] = p;
-          }
-        });
-        
-        allPosts = incoming.map(p => {
-          const old = oldMap[p.id];
-          if (old) {
-            return {
-              ...p,
-              post_text: old.post_text !== old.default_text ? old.post_text : p.post_text,
-              post_date: old.post_date !== old.original_post_date ? old.post_date : p.post_date,
-              post_time: old.post_time !== old.original_post_time ? old.post_time : p.post_time,
-              enabled: old.enabled
-            };
-          }
-          return { ...p, enabled: true };
-        });
-
-        renderTable(allPosts, activeFilter);
-        updateCounts();
-        validateAllPosts();
-      })
-      .catch(err => {
-        const tbody = document.getElementById("posts-tbody");
-        if (tbody) {
-          tbody.innerHTML =
-            `<tr><td colspan="5"><div class="sm-empty"><i class="fa fa-exclamation-triangle"></i>
-            Failed to load posts. ${err.message}</div></td></tr>`;
-        }
-      })
-      .finally(() => {
-        btn.disabled = false;
-        btn.innerHTML = '<i class="fa fa-refresh"></i> Regenerate';
-      });
-  }
-
-  // ---- Render table rows ----
-  function renderTable(posts, filter) {
-    const tbody = document.getElementById("posts-tbody");
-    if (!tbody) return;
-    const visible = filter === "all" ? posts : posts.filter(p => p.type === filter);
-
-    if (!visible.length) {
-      tbody.innerHTML = `<tr><td colspan="5"><div class="sm-empty">
-        <i class="fa fa-share-alt"></i>
-        <div>No posts found for this filter.</div>
-        <small>Check that your event has the relevant data (CFP deadline, sessions, tickets).</small>
-      </div></td></tr>`;
-      updateSelectedCount();
-      return;
+  // ---- Helper functions ----
+  const Helpers = {
+    addDays(dateStr, days) {
+      const parts = dateStr.split('-');
+      const date = new Date(Date.UTC(parseInt(parts[0]), parseInt(parts[1]) - 1, parseInt(parts[2])));
+      date.setUTCDate(date.getUTCDate() + days);
+      return date.toISOString().split('T')[0];
+    },
+    getLocalTodayStr() {
+      const now = new Date();
+      return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
     }
+  };
 
-    const _now = new Date();
-    const todayStr = `${_now.getFullYear()}-${String(_now.getMonth() + 1).padStart(2, "0")}-${String(_now.getDate()).padStart(2, "0")}`;
+  // ---- State Store module ----
+  const PostState = (function () {
+    let posts = [];
+    let activeFilter = "all";
 
-    tbody.innerHTML = visible.map((p, i) => {
-      const idx = allPosts.indexOf(p);
-      const safeType = escHtml(p.type);
+    return {
+      init(incomingPosts) {
+        posts = incomingPosts;
+      },
+      get(id) {
+        return posts.find(p => p.id == id) || null;
+      },
+      getAll() {
+        return posts;
+      },
+      getFiltered() {
+        if (activeFilter === "all") return posts;
+        return posts.filter(p => p.type === activeFilter);
+      },
+      getFilter() {
+        return activeFilter;
+      },
+      setFilter(filter) {
+        activeFilter = filter;
+      },
+      update(id, updates) {
+        const post = this.get(id);
+        if (post) {
+          Object.assign(post, updates);
+        }
+        return post;
+      },
+      toggle(id, enabled) {
+        return this.update(id, { enabled });
+      },
+      selectAll(enabled) {
+        posts.forEach(p => { p.enabled = enabled; });
+      },
+      applyBulkPreset(offsetDays) {
+        let updatedCount = 0;
+        let skippedCount = 0;
+
+        posts.forEach(p => {
+          if (!p.enabled) return;
+          if (p.reference_date) {
+            p.post_date = Helpers.addDays(p.reference_date, offsetDays);
+            updatedCount++;
+          } else {
+            skippedCount++;
+          }
+        });
+
+        return { updatedCount, skippedCount };
+      },
+      applyBulkCustom(customDate, customTime) {
+        let updatedCount = 0;
+        posts.forEach(p => {
+          if (!p.enabled) return;
+          p.post_date = customDate;
+          p.post_time = customTime;
+          updatedCount++;
+        });
+        return { updatedCount };
+      },
+      validate() {
+        let pastCount = 0;
+        let placeholderCount = 0;
+        const todayStr = Helpers.getLocalTodayStr();
+
+        posts.forEach(p => {
+          if (!p.enabled) return;
+          if (p.post_date < todayStr) pastCount++;
+          if (p.post_text.includes("{") || p.post_text.includes("}")) placeholderCount++;
+        });
+
+        return { pastCount, placeholderCount };
+      }
+    };
+  })();
+
+  // ---- API Client module ----
+  const APIClient = {
+    fetchPreview() {
+      return fetch(Config.PREVIEW_URL, {
+        headers: { "X-Requested-With": "XMLHttpRequest" }
+      }).then(r => {
+        if (!r.ok) throw new Error(`HTTP error ${r.status}`);
+        return r.json();
+      });
+    },
+    saveSettings(formData) {
+      return fetch("", {
+        method: "POST",
+        headers: {
+          "X-CSRFToken": Config.CSRF_TOKEN,
+          "X-Requested-With": "XMLHttpRequest",
+        },
+        body: formData
+      }).then(r => {
+        if (!r.ok) throw new Error("Save failed");
+        if (!r.redirected) throw new Error("Form validation failed");
+        return r.text();
+      });
+    },
+    exportCSV(posts) {
+      return fetch(Config.EXPORT_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRFToken": Config.CSRF_TOKEN,
+          "X-Requested-With": "XMLHttpRequest",
+        },
+        body: JSON.stringify({ posts })
+      }).then(r => {
+        if (!r.ok) throw new Error(`Export failed: ${r.status}`);
+        return r.blob();
+      });
+    }
+  };
+
+  // ---- UI module ----
+  const UI = {
+    setWithIcon(el, text, iconClass) {
+      if (!el) return;
+      el.textContent = "";
+      if (iconClass) {
+        const icon = document.createElement("i");
+        icon.className = iconClass;
+        el.appendChild(icon);
+        el.appendChild(document.createTextNode(" " + text));
+      } else {
+        el.appendChild(document.createTextNode(text));
+      }
+    },
+
+    showToast(msg, type = "success") {
+      const toast = document.createElement("div");
+      toast.className = `sm-toast alert alert-${type === "success" ? "success" : "warning"}`;
+
+      const icon = document.createElement("i");
+      icon.className = `fa ${type === "success" ? "fa-check-circle" : "fa-warning"}`;
+      toast.appendChild(icon);
+      toast.appendChild(document.createTextNode(msg));
+
+      document.body.appendChild(toast);
+      setTimeout(() => {
+        toast.style.transition = "opacity 0.5s ease";
+        toast.style.opacity = "0";
+        setTimeout(() => toast.remove(), 500);
+      }, 3000);
+    },
+
+    showSkeleton() {
+      const tbody = document.getElementById("posts-tbody");
+      if (!tbody) return;
+      tbody.textContent = "";
+
+      for (let i = 0; i < 5; i++) {
+        const tr = document.createElement("tr");
+        tr.className = "skeleton-row";
+
+        const tdChk = document.createElement("td");
+        const bChk = document.createElement("div");
+        bChk.className = "skeleton-bar";
+        bChk.style.width = "16px";
+        bChk.style.height = "16px";
+        bChk.style.borderRadius = "3px";
+        tdChk.appendChild(bChk);
+        tr.appendChild(tdChk);
+
+        const tdType = document.createElement("td");
+        const bType = document.createElement("div");
+        bType.className = "skeleton-bar";
+        bType.style.width = "60px";
+        tdType.appendChild(bType);
+        tr.appendChild(tdType);
+
+        const tdSched = document.createElement("td");
+        const bSched = document.createElement("div");
+        bSched.className = "skeleton-bar";
+        bSched.style.width = "110px";
+        tdSched.appendChild(bSched);
+        tr.appendChild(tdSched);
+
+        const tdInput = document.createElement("td");
+        const bInput = document.createElement("div");
+        bInput.className = "skeleton-bar";
+        bInput.style.width = "125px";
+        tdInput.appendChild(bInput);
+        tr.appendChild(tdInput);
+
+        const tdText = document.createElement("td");
+        const bText = document.createElement("div");
+        bText.className = "skeleton-bar";
+        tdText.appendChild(bText);
+        tr.appendChild(tdText);
+
+        tbody.appendChild(tr);
+      }
+    },
+
+    createPostRow(p, todayStr) {
       const isDateModified = p.post_date !== p.original_post_date;
       const isTimeModified = p.post_time !== p.original_post_time;
       const isTextModified = p.post_text !== p.default_text;
@@ -118,497 +239,616 @@
       const hasPlaceholder = p.post_text.includes("{") || p.post_text.includes("}");
       const isPast = p.post_date < todayStr;
 
-      const dateClass = isDateModified ? "is-modified" : "";
-      const timeClass = isTimeModified ? "is-modified" : "";
-      const textClass = isTextModified ? "is-modified" : "";
+      const tr = document.createElement("tr");
+      tr.dataset.postId = p.id;
+      tr.dataset.type = p.type;
+      tr.className = p.enabled ? "" : "row-disabled";
 
-      const dateWarn = isPast ? `<div class="validation-warning-badge"><i class="fa fa-exclamation-triangle"></i> Scheduled in past</div>` : "";
-      const textWarn = hasPlaceholder ? `<div class="validation-warning-badge"><i class="fa fa-exclamation-triangle"></i> Unresolved placeholders</div>` : "";
+      const tdChk = document.createElement("td");
+      const chk = document.createElement("input");
+      chk.type = "checkbox";
+      chk.className = "row-chk";
+      chk.dataset.postId = p.id;
+      chk.checked = p.enabled;
+      tdChk.appendChild(chk);
+      tr.appendChild(tdChk);
 
-      let schedHtml = `<span class="sched-badge sched-na">N/A</span>`;
+      const tdType = document.createElement("td");
+      const typeSpan = document.createElement("span");
+      typeSpan.className = `type-badge type-${p.type}`;
+      typeSpan.textContent = p.type_label;
+      tdType.appendChild(typeSpan);
+      tr.appendChild(tdType);
+
+      const tdSched = document.createElement("td");
+      tdSched.className = "event-schedule-cell";
       if (p.is_schedule_associated) {
         if (p.event_schedule_display === "Unscheduled") {
-          schedHtml = `<span class="sched-badge sched-unscheduled"><i class="fa fa-clock-o"></i> Unscheduled</span>`;
+          const spanUn = document.createElement("span");
+          spanUn.className = "sched-badge sched-unscheduled";
+          this.setWithIcon(spanUn, "Unscheduled", "fa fa-clock-o");
+          tdSched.appendChild(spanUn);
         } else if (p.event_schedule_display) {
           const parts = p.event_schedule_display.split(" ");
           if (parts.length >= 3) {
             const dateStr = parts.slice(0, 3).join(" ");
             const timeStr = parts.slice(3).join(" ");
-            schedHtml = `<div class="sched-box sched-active">
-              <div class="sched-date-row"><i class="fa fa-calendar"></i> ${escHtml(dateStr)}</div>
-              <div class="sched-time-row"><i class="fa fa-clock-o"></i> ${escHtml(timeStr)}</div>
-            </div>`;
+
+            const box = document.createElement("div");
+            box.className = "sched-box sched-active";
+
+            const dRow = document.createElement("div");
+            dRow.className = "sched-date-row";
+            this.setWithIcon(dRow, dateStr, "fa fa-calendar");
+
+            const tRow = document.createElement("div");
+            tRow.className = "sched-time-row";
+            this.setWithIcon(tRow, timeStr, "fa fa-clock-o");
+
+            box.appendChild(dRow);
+            box.appendChild(tRow);
+            tdSched.appendChild(box);
           } else {
-            schedHtml = `<span class="sched-badge sched-active"><i class="fa fa-calendar"></i> ${escHtml(p.event_schedule_display)}</span>`;
+            const spanAct = document.createElement("span");
+            spanAct.className = "sched-badge sched-active";
+            this.setWithIcon(spanAct, p.event_schedule_display, "fa fa-calendar");
+            tdSched.appendChild(spanAct);
           }
         }
+      } else {
+        const spanNa = document.createElement("span");
+        spanNa.className = "sched-badge sched-na";
+        spanNa.textContent = "N/A";
+        tdSched.appendChild(spanNa);
+      }
+      tr.appendChild(tdSched);
+
+      const tdPostSched = document.createElement("td");
+      const wrap = document.createElement("div");
+      wrap.className = "post-schedule-cell-wrap";
+
+      const dateIn = document.createElement("input");
+      dateIn.type = "date";
+      dateIn.className = `form-control input-sm sm-date-input${isDateModified ? ' is-modified' : ''}`;
+      dateIn.dataset.postId = p.id;
+      dateIn.value = p.post_date;
+      wrap.appendChild(dateIn);
+
+      const timeIn = document.createElement("input");
+      timeIn.type = "time";
+      timeIn.className = `form-control input-sm sm-time-input${isTimeModified ? ' is-modified' : ''}`;
+      timeIn.dataset.postId = p.id;
+      timeIn.value = p.post_time;
+      wrap.appendChild(timeIn);
+
+      if (isDateModified || isTimeModified) {
+        const mod = document.createElement("div");
+        mod.className = "is-modified-label";
+        mod.textContent = "Modified";
+        wrap.appendChild(mod);
       }
 
-      const revertBtn = isTextModified ? `<button class="btn-revert-text" data-idx="${idx}" type="button"><i class="fa fa-undo"></i> Revert to default</button>` : "";
-      const charCount = p.post_text.length;
-      return `
-      <tr data-idx="${idx}" data-type="${safeType}" class="${p.enabled ? "" : "row-disabled"}">
-        <td>
-          <input type="checkbox" class="row-chk" data-idx="${idx}"
-            ${p.enabled ? "checked" : ""}>
-        </td>
-        <td>
-          <span class="type-badge type-${safeType}">${escHtml(p.type_label)}</span>
-        </td>
-        <td class="event-schedule-cell">
-          ${schedHtml}
-        </td>
-        <td>
-          <div class="post-schedule-cell-wrap">
-            <input type="date" class="form-control input-sm sm-date-input ${dateClass}" data-idx="${idx}" value="${escHtml(p.post_date)}">
-            <input type="time" class="form-control input-sm sm-time-input ${timeClass}" data-idx="${idx}" value="${escHtml(p.post_time)}">
-            ${isDateModified || isTimeModified ? '<div class="is-modified-label">Modified</div>' : ''}
-            ${dateWarn}
-          </div>
-        </td>
-        <td class="post-text-cell">
-          <span class="post-text-view ${textClass}" data-idx="${idx}" tabindex="0">${escHtml(p.post_text)}</span>
-          <textarea class="post-text-edit ${hasPlaceholder ? 'has-warning' : ''}" data-idx="${idx}">${escHtml(p.post_text)}</textarea>
-          <div class="char-count-wrap">
-            <span><span class="char-count">${charCount}</span> characters</span>
-            ${revertBtn}
-          </div>
-          ${textWarn}
-        </td>
-      </tr>`;
-    }).join("");
-
-    updateSelectedCount();
-  }
-
-  // ---- Inline editing ----
-  function startEdit(idx, span) {
-    const cell = span.closest(".post-text-cell");
-    if (!cell) return;
-    const ta = cell.querySelector(".post-text-edit");
-    span.classList.add("editing");
-    if (ta) {
-      ta.classList.add("editing");
-      ta.style.display = "block";
-      ta.focus();
-      ta.setSelectionRange(ta.value.length, ta.value.length);
-    }
-  }
-
-  // Focusout / blur
-  function finishEdit(idx, ta) {
-    allPosts[idx].post_text = ta.value;
-    renderTable(allPosts, activeFilter);
-    validateAllPosts();
-  }
-
-  // Revert to template
-  function revertPostText(idx) {
-    const post = allPosts[idx];
-    if (post && post.default_text !== undefined) {
-      post.post_text = post.default_text;
-      renderTable(allPosts, activeFilter);
-      validateAllPosts();
-      showToast("Reverted post text to template default.", "success");
-    }
-  }
-
-  // ---- Toggle row ----
-  function toggleRow(idx, enabled) {
-    allPosts[idx].enabled = enabled;
-    const row = document.querySelector(`tr[data-idx="${idx}"]`);
-    if (row) row.classList.toggle("row-disabled", !enabled);
-    updateSelectedCount();
-    validateAllPosts();
-  }
-
-  // ---- Select all / none ----
-  function selectAll(val) {
-    allPosts.forEach((p, i) => { p.enabled = val; });
-    document.querySelectorAll(".row-chk").forEach(chk => {
-      const idx = parseInt(chk.dataset.idx);
-      chk.checked = val;
-      const row = chk.closest("tr");
-      if (row) row.classList.toggle("row-disabled", !val);
-    });
-    const chkAll = document.getElementById("chk-all");
-    if (chkAll) {
-      chkAll.checked = val;
-      chkAll.indeterminate = false;
-    }
-    updateSelectedCount();
-    validateAllPosts();
-  }
-
-  // ---- Filter ----
-  function filterPosts(type, btn) {
-    activeFilter = type;
-    document.querySelectorAll(".sm-filter-btn").forEach(b => b.classList.remove("active"));
-    btn.classList.add("active");
-    renderTable(allPosts, type);
-    validateAllPosts();
-  }
-
-  // ---- Update counters ----
-  function updateCounts() {
-    const types = ["cfp", "speaker", "session", "ticket", "schedule"];
-    const cntAll = document.getElementById("cnt-all");
-    if (cntAll) cntAll.textContent = allPosts.length;
-    types.forEach(t => {
-      const el = document.getElementById(`cnt-${t}`);
-      if (el) el.textContent = allPosts.filter(p => p.type === t).length;
-    });
-    updateSelectedCount();
-  }
-
-  function updateSelectedCount() {
-    const n = allPosts.filter(p => p.enabled).length;
-    const total = allPosts.length;
-    const selCount = document.getElementById("selected-count");
-    if (selCount) selCount.textContent = `${n} / ${total} selected`;
-    
-    const expCount = document.getElementById("export-count");
-    if (expCount) expCount.textContent = `${n} post${n !== 1 ? "s" : ""} selected`;
-
-    const allChk = document.getElementById("chk-all");
-    if (allChk) {
-      allChk.checked = n === total && total > 0;
-      allChk.indeterminate = n > 0 && n < total;
-    }
-  }
-
-  // ---- Validation checks ----
-  function validateAllPosts() {
-    let pastCount = 0;
-    let placeholderCount = 0;
-    const _now = new Date();
-    const todayStr = `${_now.getFullYear()}-${String(_now.getMonth() + 1).padStart(2, "0")}-${String(_now.getDate()).padStart(2, "0")}`;
-
-    allPosts.forEach(p => {
-      if (!p.enabled) return;
-      if (p.post_date < todayStr) {
-        pastCount++;
+      if (isPast) {
+        const warn = document.createElement("div");
+        warn.className = "validation-warning-badge";
+        this.setWithIcon(warn, "Scheduled in past", "fa fa-exclamation-triangle");
+        wrap.appendChild(warn);
       }
-      if (p.post_text.includes("{") || p.post_text.includes("}")) {
-        placeholderCount++;
+      tdPostSched.appendChild(wrap);
+      tr.appendChild(tdPostSched);
+
+      const tdContent = document.createElement("td");
+      tdContent.className = "post-text-cell";
+
+      const viewSpan = document.createElement("span");
+      viewSpan.className = `post-text-view${isTextModified ? ' is-modified' : ''}`;
+      viewSpan.dataset.postId = p.id;
+      viewSpan.tabIndex = 0;
+      viewSpan.textContent = p.post_text;
+      tdContent.appendChild(viewSpan);
+
+      const editArea = document.createElement("textarea");
+      editArea.className = `post-text-edit${hasPlaceholder ? ' has-warning' : ''}`;
+      editArea.dataset.postId = p.id;
+      editArea.value = p.post_text;
+      
+      const cWrap = document.createElement("div");
+      cWrap.className = "char-count-wrap";
+      const charSpan = document.createElement("span");
+      const numSpan = document.createElement("span");
+      numSpan.className = "char-count";
+      numSpan.textContent = p.post_text.length;
+      charSpan.appendChild(numSpan);
+      charSpan.appendChild(document.createTextNode(" characters"));
+      cWrap.appendChild(charSpan);
+
+      if (isTextModified) {
+        const revertBtn = document.createElement("button");
+        revertBtn.className = "btn-revert-text";
+        revertBtn.dataset.postId = p.id;
+        revertBtn.type = "button";
+        this.setWithIcon(revertBtn, "Revert to default", "fa fa-undo");
+        cWrap.appendChild(revertBtn);
       }
-    });
+      tdContent.appendChild(cWrap);
 
-    const alertContainer = document.getElementById("validation-alert-container");
-    if (!alertContainer) return;
-
-    if (pastCount > 0 || placeholderCount > 0) {
-      let html = `<div class="alert alert-warning sm-validation-alert">`;
-      html += `<strong>Warning:</strong> `;
-      const parts = [];
-      if (pastCount > 0) {
-        parts.push(`${pastCount} active post(s) scheduled in the past`);
+      if (hasPlaceholder) {
+        const warn = document.createElement("div");
+        warn.className = "validation-warning-badge";
+        this.setWithIcon(warn, "Unresolved placeholders", "fa fa-exclamation-triangle");
+        tdContent.appendChild(warn);
       }
-      if (placeholderCount > 0) {
-        parts.push(`${placeholderCount} post(s) with unresolved placeholders (e.g. {tag})`);
-      }
-      html += parts.join(" and ") + `. Review highlighted rows before exporting.`;
-      html += `</div>`;
-      alertContainer.innerHTML = html;
-      alertContainer.style.display = "block";
-    } else {
-      alertContainer.style.display = "none";
-      alertContainer.innerHTML = "";
-    }
-  }
 
-  // ---- Apply bulk scheduling ----
-  function applyBulkSchedule() {
-    const preset = document.getElementById("bulk-schedule-preset").value;
-    if (!preset) {
-      alert("Please select a schedule preset first.");
-      return;
-    }
+      tdContent.appendChild(editArea);
+      tr.appendChild(tdContent);
+      return tr;
+    },
 
-    const selected = allPosts.filter(p => p.enabled);
-    if (!selected.length) {
-      alert("Please select at least one post row to apply scheduling.");
-      return;
-    }
+    renderTable(posts, filter) {
+      const tbody = document.getElementById("posts-tbody");
+      if (!tbody) return;
+      tbody.textContent = "";
 
-    let updatedCount = 0;
-    let skippedCount = 0;
+      const visible = filter === "all" ? posts : posts.filter(p => p.type === filter);
 
-    if (preset === "custom") {
-      const customDate = document.getElementById("bulk-schedule-custom-date").value;
-      const customTime = document.getElementById("bulk-schedule-custom-time").value;
-      if (!customDate || !customTime) {
-        alert("Please select both a custom date and time.");
+      if (!visible.length) {
+        const tr = document.createElement("tr");
+        const td = document.createElement("td");
+        td.colSpan = 5;
+
+        const emptyDiv = document.createElement("div");
+        emptyDiv.className = "sm-empty";
+        
+        const icon = document.createElement("i");
+        icon.className = "fa fa-share-alt";
+        emptyDiv.appendChild(icon);
+
+        const heading = document.createElement("div");
+        heading.textContent = "No posts found for this filter.";
+        emptyDiv.appendChild(heading);
+
+        const desc = document.createElement("small");
+        desc.textContent = "Check that your event has the relevant data (CFP deadline, sessions, tickets).";
+        emptyDiv.appendChild(desc);
+
+        td.appendChild(emptyDiv);
+        tr.appendChild(td);
+        tbody.appendChild(tr);
+
+        this.updateSelectedCount();
         return;
       }
-      selected.forEach(p => {
-        p.post_date = customDate;
-        p.post_time = customTime;
-        updatedCount++;
+
+      const todayStr = Helpers.getLocalTodayStr();
+      const fragment = document.createDocumentFragment();
+      visible.forEach(p => {
+        fragment.appendChild(this.createPostRow(p, todayStr));
       });
-    } else {
-      const offsetDays = parseInt(preset);
-      selected.forEach(p => {
-        if (p.reference_date) {
-          p.post_date = addDays(p.reference_date, offsetDays);
-          updatedCount++;
-        } else {
-          skippedCount++;
+      tbody.appendChild(fragment);
+
+      this.updateSelectedCount();
+    },
+
+    updateCounts() {
+      const posts = PostState.getAll();
+      const types = ["cfp", "speaker", "session", "ticket", "schedule"];
+
+      const cntAll = document.getElementById("cnt-all");
+      if (cntAll) cntAll.textContent = posts.length;
+
+      types.forEach(t => {
+        const el = document.getElementById(`cnt-${t}`);
+        if (el) el.textContent = posts.filter(p => p.type === t).length;
+      });
+
+      this.updateSelectedCount();
+    },
+
+    updateSelectedCount() {
+      const posts = PostState.getAll();
+      const n = posts.filter(p => p.enabled).length;
+      const total = posts.length;
+
+      const selCount = document.getElementById("selected-count");
+      if (selCount) selCount.textContent = `${n} / ${total} selected`;
+
+      const expCount = document.getElementById("export-count");
+      if (expCount) expCount.textContent = `${n} post${n !== 1 ? "s" : ""} selected`;
+
+      const allChk = document.getElementById("chk-all");
+      if (allChk) {
+        allChk.checked = n === total && total > 0;
+        allChk.indeterminate = n > 0 && n < total;
+      }
+    },
+
+    updateRow(id) {
+      const post = PostState.get(id);
+      if (!post) return;
+
+      const row = document.querySelector(`tr[data-post-id="${id}"]`);
+      if (!row) return;
+
+      const todayStr = Helpers.getLocalTodayStr();
+      const newRow = this.createPostRow(post, todayStr);
+      row.replaceWith(newRow);
+
+      this.updateSelectedCount();
+    },
+
+    renderValidationAlert(pastCount, placeholderCount) {
+      const alertContainer = document.getElementById("validation-alert-container");
+      if (!alertContainer) return;
+
+      if (pastCount > 0 || placeholderCount > 0) {
+        const alertDiv = document.createElement("div");
+        alertDiv.className = "alert alert-warning sm-validation-alert";
+
+        const strong = document.createElement("strong");
+        strong.textContent = "Warning: ";
+        alertDiv.appendChild(strong);
+
+        const parts = [];
+        if (pastCount > 0) {
+          parts.push(`${pastCount} active post(s) scheduled in the past`);
         }
-      });
-    }
-
-    renderTable(allPosts, activeFilter);
-    validateAllPosts();
-
-    let msg = `Applied preset to ${updatedCount} post(s).`;
-    if (skippedCount > 0) {
-      msg += ` (${skippedCount} post(s) skipped due to missing reference dates).`;
-    }
-    showToast(msg, "success");
-  }
-
-  // ---- Export CSV ----
-  function exportCSV() {
-    const selected = allPosts.filter(p => p.enabled);
-    if (!selected.length) {
-      alert(TRANS_SELECT_AT_LEAST_ONE);
-      return;
-    }
-
-    fetch(EXPORT_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-CSRFToken": CSRF_TOKEN,
-        "X-Requested-With": "XMLHttpRequest",
-      },
-      body: JSON.stringify({ posts: allPosts }),
-    })
-      .then(r => {
-        if (!r.ok) throw new Error("Export failed: " + r.status);
-        return r.blob();
-      })
-      .then(blob => {
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = "socialmedia_posts.csv";
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-        URL.revokeObjectURL(url);
-
-        showToast(`Successfully exported ${selected.length} post(s).`, "success");
-      })
-      .catch(err => alert("Export error: " + err.message));
-  }
-
-  // ---- Advanced settings toggle ----
-  function toggleAdv() {
-    const body = document.getElementById("adv-body");
-    const hdr  = document.getElementById("adv-toggle");
-    if (body && hdr) {
-      const open = body.classList.toggle("open");
-      hdr.classList.toggle("open", open);
-    }
-  }
-
-  // ---- Skeleton helper ----
-  function showSkeleton() {
-    const tbody = document.getElementById("posts-tbody");
-    if (tbody) {
-      tbody.innerHTML = `
-        ${[...Array(5)].map(() => `<tr class="skeleton-row">
-          <td><div class="skeleton-bar" style="width:16px;height:16px;border-radius:3px;"></div></td>
-          <td><div class="skeleton-bar" style="width:60px;"></div></td>
-          <td><div class="skeleton-bar" style="width:110px;"></div></td>
-          <td><div class="skeleton-bar" style="width:125px;"></div></td>
-          <td><div class="skeleton-bar"></div></td>
-        </tr>`).join("")}`;
-    }
-  }
-
-  function escHtml(str) {
-    return String(str)
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;");
-  }
-
-  // ---- Save settings & regenerate preview ----
-  function saveAndRegenerate(e) {
-    e.preventDefault();
-    const btn = document.getElementById("btn-save-regenerate");
-    if (!btn) return;
-    btn.disabled = true;
-    btn.innerHTML = '<i class="fa fa-refresh"></i> Saving…';
-
-    const form = btn.closest("form");
-    const formData = new FormData(form);
-
-    fetch("", {
-      method: "POST",
-      headers: {
-        "X-CSRFToken": CSRF_TOKEN,
-        "X-Requested-With": "XMLHttpRequest",
-      },
-      body: formData
-    })
-      .then(r => {
-        if (!r.ok) throw new Error("Save failed");
-        // If not redirected, form was invalid (returned 200 same template with errors)
-        if (!r.redirected) {
-          throw new Error("Form validation failed");
+        if (placeholderCount > 0) {
+          parts.push(`${placeholderCount} post(s) with unresolved placeholders (e.g. {tag})`);
         }
-        return r.text();
-      })
-      .then(() => {
-        showToast("Settings saved successfully.", "success");
-        loadPosts();
-      })
-      .catch(err => {
-        // Fallback: submit normally so user can see validation error highlights
-        form.submit();
-      })
-      .finally(() => {
-        btn.disabled = false;
-        btn.innerHTML = '<i class="fa fa-refresh"></i> Save & Regenerate Preview';
-      });
-  }
 
-  // ---- Event Bindings ----
-  function bindEvents() {
-    const btnRegen = document.getElementById("btn-regenerate");
-    if (btnRegen) btnRegen.addEventListener("click", loadPosts);
+        alertDiv.appendChild(document.createTextNode(parts.join(" and ") + ". Review highlighted rows before exporting."));
+        alertContainer.textContent = "";
+        alertContainer.appendChild(alertDiv);
+        alertContainer.style.display = "block";
+      } else {
+        alertContainer.style.display = "none";
+        alertContainer.textContent = "";
+      }
+    },
 
-    const btnSaveRegen = document.getElementById("btn-save-regenerate");
-    if (btnSaveRegen) btnSaveRegen.addEventListener("click", saveAndRegenerate);
+    startEdit(id) {
+      const row = document.querySelector(`tr[data-post-id="${id}"]`);
+      if (!row) return;
 
-    const filterPills = document.getElementById("filter-pills");
-    if (filterPills) {
-      filterPills.addEventListener("click", function (e) {
-        const btn = e.target.closest(".sm-filter-btn");
-        if (btn) {
-          filterPosts(btn.dataset.type, btn);
+      const viewSpan = row.querySelector(".post-text-view");
+      const editArea = row.querySelector(".post-text-edit");
+      if (viewSpan && editArea) {
+        viewSpan.classList.add("editing");
+        editArea.classList.add("editing");
+        editArea.style.display = "block";
+        editArea.focus();
+        editArea.setSelectionRange(editArea.value.length, editArea.value.length);
+      }
+    },
+
+    finishEdit(id, value) {
+      PostState.update(id, { post_text: value });
+      this.updateRow(id);
+      AppController.triggerValidation();
+    },
+
+    revertPostText(id) {
+      const post = PostState.get(id);
+      if (post && post.default_text !== undefined) {
+        PostState.update(id, { post_text: post.default_text });
+        this.updateRow(id);
+        AppController.triggerValidation();
+        this.showToast("Reverted post text to template default.", "success");
+      }
+    },
+
+    toggleRow(id, enabled) {
+      PostState.toggle(id, enabled);
+      const row = document.querySelector(`tr[data-post-id="${id}"]`);
+      if (row) {
+        row.classList.toggle("row-disabled", !enabled);
+      }
+      this.updateSelectedCount();
+      AppController.triggerValidation();
+    },
+
+    toggleAdv() {
+      const body = document.getElementById("adv-body");
+      const hdr = document.getElementById("adv-toggle");
+      if (body && hdr) {
+        const open = body.classList.toggle("open");
+        hdr.classList.toggle("open", open);
+      }
+    }
+  };
+
+  // ---- App Controller module (Orchestration) ----
+  const AppController = {
+    init() {
+      this.bindEvents();
+      this.loadInitialData();
+    },
+
+    loadInitialData() {
+      const btn = document.getElementById("btn-regenerate");
+      if (btn) {
+        btn.disabled = true;
+        UI.setWithIcon(btn, "Loading…", "fa fa-refresh");
+      }
+      UI.showSkeleton();
+
+      APIClient.fetchPreview()
+        .then(data => {
+          const incoming = data.posts || [];
+          const oldMap = {};
+          PostState.getAll().forEach(p => {
+            if (p.id) oldMap[p.id] = p;
+          });
+
+          const posts = incoming.map(p => {
+            const old = oldMap[p.id];
+            if (old) {
+              return {
+                ...p,
+                post_text: old.post_text !== old.default_text ? old.post_text : p.post_text,
+                post_date: old.post_date !== old.original_post_date ? old.post_date : p.post_date,
+                post_time: old.post_time !== old.original_post_time ? old.post_time : p.post_time,
+                enabled: old.enabled
+              };
+            }
+            return { ...p, enabled: true };
+          });
+
+          PostState.init(posts);
+          UI.renderTable(PostState.getAll(), PostState.getFilter());
+          UI.updateCounts();
+          this.triggerValidation();
+        })
+        .catch(err => {
+          const tbody = document.getElementById("posts-tbody");
+          if (tbody) {
+            tbody.textContent = "";
+            const tr = document.createElement("tr");
+            const td = document.createElement("td");
+            td.colSpan = 5;
+
+            const emptyDiv = document.createElement("div");
+            emptyDiv.className = "sm-empty";
+            
+            const icon = document.createElement("i");
+            icon.className = "fa fa-exclamation-triangle";
+            emptyDiv.appendChild(icon);
+            emptyDiv.appendChild(document.createTextNode(" Failed to load posts. " + err.message));
+
+            td.appendChild(emptyDiv);
+            tr.appendChild(td);
+            tbody.appendChild(tr);
+          }
+        })
+        .finally(() => {
+          if (btn) {
+            btn.disabled = false;
+            UI.setWithIcon(btn, "Regenerate", "fa fa-refresh");
+          }
+        });
+    },
+
+    triggerValidation() {
+      const { pastCount, placeholderCount } = PostState.validate();
+      UI.renderValidationAlert(pastCount, placeholderCount);
+    },
+
+    saveAndRegenerate(e) {
+      e.preventDefault();
+      const btn = document.getElementById("btn-save-regenerate");
+      if (!btn) return;
+      btn.disabled = true;
+      UI.setWithIcon(btn, "Saving…", "fa fa-refresh");
+
+      const form = btn.closest("form");
+      const formData = new FormData(form);
+
+      APIClient.saveSettings(formData)
+        .then(() => {
+          UI.showToast("Settings saved successfully.", "success");
+          this.loadInitialData();
+        })
+        .catch(() => {
+          form.submit();
+        })
+        .finally(() => {
+          btn.disabled = false;
+          UI.setWithIcon(btn, "Save & Regenerate Preview", "fa fa-refresh");
+        });
+    },
+
+    applyBulkSchedule() {
+      const preset = document.getElementById("bulk-schedule-preset").value;
+      if (!preset) {
+        alert("Please select a schedule preset first.");
+        return;
+      }
+
+      const enabledPosts = PostState.getAll().filter(p => p.enabled);
+      if (!enabledPosts.length) {
+        alert("Please select at least one post row to apply scheduling.");
+        return;
+      }
+
+      let res;
+      if (preset === "custom") {
+        const customDate = document.getElementById("bulk-schedule-custom-date").value;
+        const customTime = document.getElementById("bulk-schedule-custom-time").value;
+        if (!customDate || !customTime) {
+          alert("Please select both a custom date and time.");
+          return;
         }
-      });
-    }
+        res = PostState.applyBulkCustom(customDate, customTime);
+      } else {
+        const offsetDays = parseInt(preset);
+        res = PostState.applyBulkPreset(offsetDays);
+      }
 
+      UI.renderTable(PostState.getAll(), PostState.getFilter());
+      this.triggerValidation();
 
-    const chkAll = document.getElementById("chk-all");
-    if (chkAll) {
-      chkAll.addEventListener("change", function () {
-        selectAll(this.checked);
-      });
-    }
+      let msg = `Applied preset to ${res.updatedCount || 0} post(s).`;
+      if (res.skippedCount > 0) {
+        msg += ` (${res.skippedCount} post(s) skipped due to missing reference dates).`;
+      }
+      UI.showToast(msg, "success");
+    },
 
-    const btnExport = document.getElementById("btn-export");
-    if (btnExport) {
-      btnExport.addEventListener("click", exportCSV);
-    }
+    exportCSV() {
+      const enabledPosts = PostState.getAll().filter(p => p.enabled);
+      if (!enabledPosts.length) {
+        alert(Config.TRANS_SELECT_AT_LEAST_ONE);
+        return;
+      }
 
-    const advToggle = document.getElementById("adv-toggle");
-    if (advToggle) {
-      advToggle.addEventListener("click", toggleAdv);
-    }
+      APIClient.exportCSV(PostState.getAll())
+        .then(blob => {
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = "socialmedia_posts.csv";
+          document.body.appendChild(a);
+          a.click();
+          a.remove();
+          URL.revokeObjectURL(url);
 
-    // Bulk scheduling preset change & apply bindings
-    const presetSel = document.getElementById("bulk-schedule-preset");
-    const customInputs = document.getElementById("bulk-schedule-custom-inputs");
-    if (presetSel && customInputs) {
-      presetSel.addEventListener("change", function () {
-        if (this.value === "custom") {
-          customInputs.style.display = "flex";
-        } else {
-          customInputs.style.display = "none";
-        }
-      });
-    }
+          UI.showToast(`Successfully exported ${enabledPosts.length} post(s).`, "success");
+        })
+        .catch(err => alert(`Export error: ${err.message}`));
+    },
 
-    const btnApplySchedule = document.getElementById("btn-apply-schedule");
-    if (btnApplySchedule) {
-      btnApplySchedule.addEventListener("click", applyBulkSchedule);
-    }
+    bindEvents() {
+      const btnRegen = document.getElementById("btn-regenerate");
+      if (btnRegen) btnRegen.addEventListener("click", () => this.loadInitialData());
 
-    // Attach tbody event delegation
-    const tbody = document.getElementById("posts-tbody");
-    if (tbody) {
-      tbody.addEventListener("click", function (e) {
-        if (e.target.classList.contains("post-text-view")) {
-          const idx = parseInt(e.target.dataset.idx);
-          startEdit(idx, e.target);
-        } else if (e.target.closest(".btn-revert-text")) {
-          const btn = e.target.closest(".btn-revert-text");
-          const idx = parseInt(btn.dataset.idx);
-          revertPostText(idx);
-        }
-      });
+      const btnSaveRegen = document.getElementById("btn-save-regenerate");
+      if (btnSaveRegen) btnSaveRegen.addEventListener("click", (e) => this.saveAndRegenerate(e));
 
-      tbody.addEventListener("change", function (e) {
-        if (e.target.classList.contains("row-chk")) {
-          const idx = parseInt(e.target.dataset.idx);
-          toggleRow(idx, e.target.checked);
-        } else if (e.target.classList.contains("sm-date-input")) {
-          const idx = parseInt(e.target.dataset.idx);
-          allPosts[idx].post_date = e.target.value;
-          renderTable(allPosts, activeFilter);
-          validateAllPosts();
-        } else if (e.target.classList.contains("sm-time-input")) {
-          const idx = parseInt(e.target.dataset.idx);
-          allPosts[idx].post_time = e.target.value;
-          renderTable(allPosts, activeFilter);
-          validateAllPosts();
-        }
-      });
+      const filterPills = document.getElementById("filter-pills");
+      if (filterPills) {
+        filterPills.addEventListener("click", (e) => {
+          const btn = e.target.closest(".sm-filter-btn");
+          if (btn) {
+            PostState.setFilter(btn.dataset.type);
+            document.querySelectorAll(".sm-filter-btn").forEach(b => b.classList.remove("active"));
+            btn.classList.add("active");
+            UI.renderTable(PostState.getAll(), PostState.getFilter());
+            this.triggerValidation();
+          }
+        });
+      }
 
-      tbody.addEventListener("input", function (e) {
-        if (e.target.classList.contains("post-text-edit")) {
-          const idx = parseInt(e.target.dataset.idx);
-          allPosts[idx].post_text = e.target.value;
-          
-          const cell = e.target.closest(".post-text-cell");
-          if (cell) {
-            const countSpan = cell.querySelector(".char-count");
-            if (countSpan) {
-              countSpan.textContent = e.target.value.length;
+      const chkAll = document.getElementById("chk-all");
+      if (chkAll) {
+        chkAll.addEventListener("change", (e) => {
+          const checked = e.target.checked;
+          PostState.selectAll(checked);
+
+          document.querySelectorAll(".row-chk").forEach(chk => {
+            chk.checked = checked;
+            const row = chk.closest("tr");
+            if (row) row.classList.toggle("row-disabled", !checked);
+          });
+
+          UI.updateSelectedCount();
+          this.triggerValidation();
+        });
+      }
+
+      const btnExport = document.getElementById("btn-export");
+      if (btnExport) btnExport.addEventListener("click", () => this.exportCSV());
+
+      const advToggle = document.getElementById("adv-toggle");
+      if (advToggle) advToggle.addEventListener("click", () => UI.toggleAdv());
+
+      const presetSel = document.getElementById("bulk-schedule-preset");
+      const customInputs = document.getElementById("bulk-schedule-custom-inputs");
+      if (presetSel && customInputs) {
+        presetSel.addEventListener("change", function () {
+          customInputs.style.display = this.value === "custom" ? "flex" : "none";
+        });
+      }
+
+      const btnApplySchedule = document.getElementById("btn-apply-schedule");
+      if (btnApplySchedule) btnApplySchedule.addEventListener("click", () => this.applyBulkSchedule());
+
+      const tbody = document.getElementById("posts-tbody");
+      if (tbody) {
+        tbody.addEventListener("click", (e) => {
+          const tr = e.target.closest("[data-post-id]");
+          if (!tr) return;
+          const postId = tr.dataset.postId;
+
+          if (e.target.classList.contains("post-text-view")) {
+            UI.startEdit(postId);
+          } else if (e.target.closest(".btn-revert-text")) {
+            UI.revertPostText(postId);
+          }
+        });
+
+        tbody.addEventListener("change", (e) => {
+          const postId = e.target.dataset.postId;
+          if (!postId) return;
+
+          if (e.target.classList.contains("row-chk")) {
+            UI.toggleRow(postId, e.target.checked);
+          } else if (e.target.classList.contains("sm-date-input")) {
+            PostState.update(postId, { post_date: e.target.value });
+            UI.updateRow(postId);
+            this.triggerValidation();
+          } else if (e.target.classList.contains("sm-time-input")) {
+            PostState.update(postId, { post_time: e.target.value });
+            UI.updateRow(postId);
+            this.triggerValidation();
+          }
+        });
+
+        tbody.addEventListener("input", (e) => {
+          const postId = e.target.dataset.postId;
+          if (!postId) return;
+
+          if (e.target.classList.contains("post-text-edit")) {
+            PostState.update(postId, { post_text: e.target.value });
+            const row = e.target.closest("tr");
+            if (row) {
+              const countSpan = row.querySelector(".char-count");
+              if (countSpan) countSpan.textContent = e.target.value.length;
             }
           }
-        }
-      });
+        });
 
-      tbody.addEventListener("keydown", function (e) {
-        if (e.target.classList.contains("post-text-view")) {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            const idx = parseInt(e.target.dataset.idx);
-            startEdit(idx, e.target);
-          }
-        } else if (e.target.classList.contains("post-text-edit")) {
-          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-            e.target.blur();
-          }
-        }
-      });
+        tbody.addEventListener("keydown", (e) => {
+          const postId = e.target.dataset.postId;
+          if (!postId) return;
 
-      tbody.addEventListener("focusout", function (e) {
-        if (e.target.classList.contains("post-text-edit")) {
-          const idx = parseInt(e.target.dataset.idx);
-          finishEdit(idx, e.target);
-        }
-      });
+          if (e.target.classList.contains("post-text-view")) {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              UI.startEdit(postId);
+            }
+          } else if (e.target.classList.contains("post-text-edit")) {
+            if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+              e.target.blur();
+            }
+          }
+        });
+
+        tbody.addEventListener("focusout", (e) => {
+          const postId = e.target.dataset.postId;
+          if (!postId) return;
+
+          if (e.target.classList.contains("post-text-edit")) {
+            UI.finishEdit(postId, e.target.value);
+          }
+        });
+      }
     }
-  }
+  };
 
-  // Auto-load and bind on page ready
+  // Run on load
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", () => {
-      bindEvents();
-      loadPosts();
-    });
+    document.addEventListener("DOMContentLoaded", () => AppController.init());
   } else {
-    bindEvents();
-    loadPosts();
+    AppController.init();
   }
 })();

--- a/socialmedia/static/socialmedia/js/settings.js
+++ b/socialmedia/static/socialmedia/js/settings.js
@@ -12,6 +12,34 @@
   let allPosts = [];   // full data from server
   let activeFilter = "all";
 
+  // ---- Helper for date calculation ----
+  function addDays(dateStr, days) {
+    const parts = dateStr.split('-');
+    const date = new Date(Date.UTC(parseInt(parts[0]), parseInt(parts[1]) - 1, parseInt(parts[2])));
+    date.setUTCDate(date.getUTCDate() + days);
+    return date.toISOString().split('T')[0];
+  }
+
+  // ---- Toast notifications ----
+  function showToast(msg, type = "success") {
+    const toast = document.createElement("div");
+    toast.className = `alert alert-${type === "success" ? "success" : "warning"}`;
+    toast.style.position = "fixed";
+    toast.style.top = "20px";
+    toast.style.right = "20px";
+    toast.style.zIndex = "9999";
+    toast.style.boxShadow = "0 4px 12px rgba(0,0,0,0.15)";
+    toast.style.padding = "12px 20px";
+    toast.style.margin = "0";
+    toast.innerHTML = `<i class="fa ${type === "success" ? "fa-check-circle" : "fa-warning"}"></i> ${msg}`;
+    document.body.appendChild(toast);
+    setTimeout(() => {
+      toast.style.opacity = "0";
+      toast.style.transition = "opacity 0.5s ease";
+      setTimeout(() => toast.remove(), 500);
+    }, 3000);
+  }
+
   // ---- Load posts from server ----
   function loadPosts() {
     const btn = document.getElementById("btn-regenerate");
@@ -23,9 +51,31 @@
     fetch(PREVIEW_URL, { headers: { "X-Requested-With": "XMLHttpRequest" } })
       .then(r => r.json())
       .then(data => {
-        allPosts = (data.posts || []).map(p => ({ ...p, enabled: true }));
+        const incoming = data.posts || [];
+        const oldMap = {};
+        allPosts.forEach(p => {
+          if (p.id) {
+            oldMap[p.id] = p;
+          }
+        });
+        
+        allPosts = incoming.map(p => {
+          const old = oldMap[p.id];
+          if (old) {
+            return {
+              ...p,
+              post_text: old.post_text !== old.default_text ? old.post_text : p.post_text,
+              post_date: old.post_date !== old.original_post_date ? old.post_date : p.post_date,
+              post_time: old.post_time !== old.original_post_time ? old.post_time : p.post_time,
+              enabled: old.enabled
+            };
+          }
+          return { ...p, enabled: true };
+        });
+
         renderTable(allPosts, activeFilter);
         updateCounts();
+        validateAllPosts();
       })
       .catch(err => {
         const tbody = document.getElementById("posts-tbody");
@@ -57,27 +107,55 @@
       return;
     }
 
+    const todayStr = new Date().toISOString().split('T')[0];
+
     tbody.innerHTML = visible.map((p, i) => {
       const idx = allPosts.indexOf(p);
       const safeType = escHtml(p.type);
+      const isDateModified = p.post_date !== p.original_post_date;
+      const isTimeModified = p.post_time !== p.original_post_time;
+      const isTextModified = p.post_text !== p.default_text;
+
+      const hasPlaceholder = p.post_text.includes("{") || p.post_text.includes("}");
+      const isPast = p.post_date < todayStr;
+
+      const dateClass = isDateModified ? "is-modified" : "";
+      const timeClass = isTimeModified ? "is-modified" : "";
+      const textClass = isTextModified ? "is-modified" : "";
+
+      const refHtml = p.reference_date ? `<div class="dt-ref-date"><i class="fa fa-info-circle"></i> Ref: ${escHtml(p.reference_date)}</div>` : "";
+      const dateWarn = isPast ? `<div class="validation-warning-badge"><i class="fa fa-exclamation-triangle"></i> Scheduled in past</div>` : "";
+      const textWarn = hasPlaceholder ? `<div class="validation-warning-badge"><i class="fa fa-exclamation-triangle"></i> Unresolved placeholders</div>` : "";
+
+      const revertBtn = isTextModified ? `<button class="btn-revert-text" data-idx="${idx}" type="button"><i class="fa fa-undo"></i> Revert to default</button>` : "";
+      const charCount = p.post_text.length;
       return `
       <tr data-idx="${idx}" data-type="${safeType}" class="${p.enabled ? "" : "row-disabled"}">
         <td>
           <input type="checkbox" class="row-chk" data-idx="${idx}"
             ${p.enabled ? "checked" : ""}>
         </td>
-        <td><span class="type-badge type-${safeType}">${escHtml(p.type_label)}</span></td>
-        <td class="dt-cell">
-          <div class="dt-date">${escHtml(p.post_date)}</div>
-          <div class="dt-time">${escHtml(p.post_time)}</div>
+        <td>
+          <span class="type-badge type-${safeType}">${escHtml(p.type_label)}</span>
         </td>
-        <td class="dt-cell">
-          <input type="time" class="form-control input-sm sm-time-input" value="${escHtml(p.post_time)}">
+        <td>
+          <input type="date" class="form-control input-sm sm-date-input ${dateClass}" data-idx="${idx}" value="${escHtml(p.post_date)}">
+          ${isDateModified ? '<div class="is-modified-label">Modified</div>' : ''}
+          ${refHtml}
+          ${dateWarn}
+        </td>
+        <td>
+          <input type="time" class="form-control input-sm sm-time-input ${timeClass}" data-idx="${idx}" value="${escHtml(p.post_time)}">
+          ${isTimeModified ? '<div class="is-modified-label">Modified</div>' : ''}
         </td>
         <td class="post-text-cell">
-          <span class="post-text-view" data-idx="${idx}">${escHtml(p.post_text)}</span>
-          <textarea class="post-text-edit" data-idx="${idx}">${escHtml(p.post_text)}</textarea>
-          <span class="edit-hint">${escHtml(TRANS_CLICK_TO_EDIT)}</span>
+          <span class="post-text-view ${textClass}" data-idx="${idx}" tabindex="0">${escHtml(p.post_text)}</span>
+          <textarea class="post-text-edit ${hasPlaceholder ? 'has-warning' : ''}" data-idx="${idx}">${escHtml(p.post_text)}</textarea>
+          <div class="char-count-wrap" style="font-size: 11px; color: #888; margin-top: 4px; display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap;">
+            <span><span class="char-count">${charCount}</span> characters</span>
+            ${revertBtn}
+          </div>
+          ${textWarn}
         </td>
       </tr>`;
     }).join("");
@@ -85,35 +163,36 @@
     updateSelectedCount();
   }
 
-  function syncTimeDisplay(idx, val) {
-    const view = document.querySelector(`.post-text-view[data-idx="${idx}"]`);
-    if (view) {
-      const row = view.closest("tr");
-      const dtDate = row.querySelector(".dt-date");
-      if (dtDate) {
-        row.querySelector(".dt-time").textContent = val;
-      }
-    }
-  }
-
   // ---- Inline editing ----
   function startEdit(idx, span) {
-    const ta = span.nextElementSibling;
+    const cell = span.closest(".post-text-cell");
+    if (!cell) return;
+    const ta = cell.querySelector(".post-text-edit");
     span.classList.add("editing");
-    ta.classList.add("editing");
-    ta.style.display = "block";
-    ta.focus();
-    ta.setSelectionRange(ta.value.length, ta.value.length);
+    if (ta) {
+      ta.classList.add("editing");
+      ta.style.display = "block";
+      ta.focus();
+      ta.setSelectionRange(ta.value.length, ta.value.length);
+    }
   }
 
   // Focusout / blur
   function finishEdit(idx, ta) {
     allPosts[idx].post_text = ta.value;
-    const span = ta.previousElementSibling;
-    span.textContent = ta.value;
-    span.classList.remove("editing");
-    ta.classList.remove("editing");
-    ta.style.display = "none";
+    renderTable(allPosts, activeFilter);
+    validateAllPosts();
+  }
+
+  // Revert to template
+  function revertPostText(idx) {
+    const post = allPosts[idx];
+    if (post && post.default_text !== undefined) {
+      post.post_text = post.default_text;
+      renderTable(allPosts, activeFilter);
+      validateAllPosts();
+      showToast("Reverted post text to template default.", "success");
+    }
   }
 
   // ---- Toggle row ----
@@ -122,6 +201,7 @@
     const row = document.querySelector(`tr[data-idx="${idx}"]`);
     if (row) row.classList.toggle("row-disabled", !enabled);
     updateSelectedCount();
+    validateAllPosts();
   }
 
   // ---- Select all / none ----
@@ -139,6 +219,7 @@
       chkAll.indeterminate = false;
     }
     updateSelectedCount();
+    validateAllPosts();
   }
 
   // ---- Filter ----
@@ -147,6 +228,7 @@
     document.querySelectorAll(".sm-filter-btn").forEach(b => b.classList.remove("active"));
     btn.classList.add("active");
     renderTable(allPosts, type);
+    validateAllPosts();
   }
 
   // ---- Update counters ----
@@ -175,6 +257,96 @@
       allChk.checked = n === total && total > 0;
       allChk.indeterminate = n > 0 && n < total;
     }
+  }
+
+  // ---- Validation checks ----
+  function validateAllPosts() {
+    let pastCount = 0;
+    let placeholderCount = 0;
+    const todayStr = new Date().toISOString().split('T')[0];
+
+    allPosts.forEach(p => {
+      if (!p.enabled) return;
+      if (p.post_date < todayStr) {
+        pastCount++;
+      }
+      if (p.post_text.includes("{") || p.post_text.includes("}")) {
+        placeholderCount++;
+      }
+    });
+
+    const alertContainer = document.getElementById("validation-alert-container");
+    if (!alertContainer) return;
+
+    if (pastCount > 0 || placeholderCount > 0) {
+      let html = `<div class="alert alert-warning" style="margin-bottom: 12px;">`;
+      html += `<strong>Warning:</strong> `;
+      const parts = [];
+      if (pastCount > 0) {
+        parts.push(`${pastCount} active post(s) scheduled in the past`);
+      }
+      if (placeholderCount > 0) {
+        parts.push(`${placeholderCount} post(s) with unresolved placeholders (e.g. {tag})`);
+      }
+      html += parts.join(" and ") + `. Review highlighted rows before exporting.`;
+      html += `</div>`;
+      alertContainer.innerHTML = html;
+      alertContainer.style.display = "block";
+    } else {
+      alertContainer.style.display = "none";
+      alertContainer.innerHTML = "";
+    }
+  }
+
+  // ---- Apply bulk scheduling ----
+  function applyBulkSchedule() {
+    const preset = document.getElementById("bulk-schedule-preset").value;
+    if (!preset) {
+      alert("Please select a schedule preset first.");
+      return;
+    }
+
+    const selected = allPosts.filter(p => p.enabled);
+    if (!selected.length) {
+      alert("Please select at least one post row to apply scheduling.");
+      return;
+    }
+
+    let updatedCount = 0;
+    let skippedCount = 0;
+
+    if (preset === "custom") {
+      const customDate = document.getElementById("bulk-schedule-custom-date").value;
+      const customTime = document.getElementById("bulk-schedule-custom-time").value;
+      if (!customDate || !customTime) {
+        alert("Please select both a custom date and time.");
+        return;
+      }
+      selected.forEach(p => {
+        p.post_date = customDate;
+        p.post_time = customTime;
+        updatedCount++;
+      });
+    } else {
+      const offsetDays = parseInt(preset);
+      selected.forEach(p => {
+        if (p.reference_date) {
+          p.post_date = addDays(p.reference_date, offsetDays);
+          updatedCount++;
+        } else {
+          skippedCount++;
+        }
+      });
+    }
+
+    renderTable(allPosts, activeFilter);
+    validateAllPosts();
+
+    let msg = `Applied preset to ${updatedCount} post(s).`;
+    if (skippedCount > 0) {
+      msg += ` (${skippedCount} post(s) skipped due to missing reference dates).`;
+    }
+    showToast(msg, "success");
   }
 
   // ---- Export CSV ----
@@ -207,6 +379,8 @@
         a.click();
         a.remove();
         URL.revokeObjectURL(url);
+
+        showToast(`Successfully exported ${selected.length} post(s).`, "success");
       })
       .catch(err => alert("Export error: " + err.message));
   }
@@ -229,8 +403,8 @@
         ${[...Array(5)].map(() => `<tr class="skeleton-row">
           <td><div class="skeleton-bar" style="width:16px;height:16px;border-radius:3px;"></div></td>
           <td><div class="skeleton-bar" style="width:60px;"></div></td>
-          <td><div class="skeleton-bar" style="width:80px;"></div></td>
-          <td><div class="skeleton-bar" style="width:50px;"></div></td>
+          <td><div class="skeleton-bar" style="width:130px;"></div></td>
+          <td><div class="skeleton-bar" style="width:100px;"></div></td>
           <td><div class="skeleton-bar"></div></td>
         </tr>`).join("")}`;
     }
@@ -244,13 +418,54 @@
       .replace(/"/g, "&quot;");
   }
 
+  // ---- Save settings & regenerate preview ----
+  function saveAndRegenerate(e) {
+    e.preventDefault();
+    const btn = document.getElementById("btn-save-regenerate");
+    if (!btn) return;
+    btn.disabled = true;
+    btn.innerHTML = '<i class="fa fa-refresh"></i> Saving…';
+
+    const form = btn.closest("form");
+    const formData = new FormData(form);
+
+    fetch("", {
+      method: "POST",
+      headers: {
+        "X-CSRFToken": CSRF_TOKEN,
+        "X-Requested-With": "XMLHttpRequest",
+      },
+      body: formData
+    })
+      .then(r => {
+        if (!r.ok) throw new Error("Save failed");
+        // If not redirected, form was invalid (returned 200 same template with errors)
+        if (!r.redirected) {
+          throw new Error("Form validation failed");
+        }
+        return r.text();
+      })
+      .then(() => {
+        showToast("Settings saved successfully.", "success");
+        loadPosts();
+      })
+      .catch(err => {
+        // Fallback: submit normally so user can see validation error highlights
+        form.submit();
+      })
+      .finally(() => {
+        btn.disabled = false;
+        btn.innerHTML = '<i class="fa fa-refresh"></i> Save & Regenerate Preview';
+      });
+  }
+
   // ---- Event Bindings ----
   function bindEvents() {
     const btnRegen = document.getElementById("btn-regenerate");
     if (btnRegen) btnRegen.addEventListener("click", loadPosts);
 
     const btnSaveRegen = document.getElementById("btn-save-regenerate");
-    if (btnSaveRegen) btnSaveRegen.addEventListener("click", loadPosts);
+    if (btnSaveRegen) btnSaveRegen.addEventListener("click", saveAndRegenerate);
 
     const filterPills = document.getElementById("filter-pills");
     if (filterPills) {
@@ -262,15 +477,6 @@
       });
     }
 
-    const btnSelectAll = document.getElementById("btn-select-all");
-    if (btnSelectAll) {
-      btnSelectAll.addEventListener("click", () => selectAll(true));
-    }
-
-    const btnDeselectAll = document.getElementById("btn-deselect-all");
-    if (btnDeselectAll) {
-      btnDeselectAll.addEventListener("click", () => selectAll(false));
-    }
 
     const chkAll = document.getElementById("chk-all");
     if (chkAll) {
@@ -289,6 +495,24 @@
       advToggle.addEventListener("click", toggleAdv);
     }
 
+    // Bulk scheduling preset change & apply bindings
+    const presetSel = document.getElementById("bulk-schedule-preset");
+    const customInputs = document.getElementById("bulk-schedule-custom-inputs");
+    if (presetSel && customInputs) {
+      presetSel.addEventListener("change", function () {
+        if (this.value === "custom") {
+          customInputs.style.display = "flex";
+        } else {
+          customInputs.style.display = "none";
+        }
+      });
+    }
+
+    const btnApplySchedule = document.getElementById("btn-apply-schedule");
+    if (btnApplySchedule) {
+      btnApplySchedule.addEventListener("click", applyBulkSchedule);
+    }
+
     // Attach tbody event delegation
     const tbody = document.getElementById("posts-tbody");
     if (tbody) {
@@ -296,6 +520,10 @@
         if (e.target.classList.contains("post-text-view")) {
           const idx = parseInt(e.target.dataset.idx);
           startEdit(idx, e.target);
+        } else if (e.target.closest(".btn-revert-text")) {
+          const btn = e.target.closest(".btn-revert-text");
+          const idx = parseInt(btn.dataset.idx);
+          revertPostText(idx);
         }
       });
 
@@ -303,16 +531,42 @@
         if (e.target.classList.contains("row-chk")) {
           const idx = parseInt(e.target.dataset.idx);
           toggleRow(idx, e.target.checked);
+        } else if (e.target.classList.contains("sm-date-input")) {
+          const idx = parseInt(e.target.dataset.idx);
+          allPosts[idx].post_date = e.target.value;
+          renderTable(allPosts, activeFilter);
+          validateAllPosts();
         } else if (e.target.classList.contains("sm-time-input")) {
-          const row = e.target.closest("tr");
-          const idx = parseInt(row.dataset.idx);
+          const idx = parseInt(e.target.dataset.idx);
           allPosts[idx].post_time = e.target.value;
-          syncTimeDisplay(idx, e.target.value);
+          renderTable(allPosts, activeFilter);
+          validateAllPosts();
+        }
+      });
+
+      tbody.addEventListener("input", function (e) {
+        if (e.target.classList.contains("post-text-edit")) {
+          const idx = parseInt(e.target.dataset.idx);
+          allPosts[idx].post_text = e.target.value;
+          
+          const cell = e.target.closest(".post-text-cell");
+          if (cell) {
+            const countSpan = cell.querySelector(".char-count");
+            if (countSpan) {
+              countSpan.textContent = e.target.value.length;
+            }
+          }
         }
       });
 
       tbody.addEventListener("keydown", function (e) {
-        if (e.target.classList.contains("post-text-edit")) {
+        if (e.target.classList.contains("post-text-view")) {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            const idx = parseInt(e.target.dataset.idx);
+            startEdit(idx, e.target);
+          }
+        } else if (e.target.classList.contains("post-text-edit")) {
           if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
             e.target.blur();
           }

--- a/socialmedia/static/socialmedia/js/settings.js
+++ b/socialmedia/static/socialmedia/js/settings.js
@@ -23,19 +23,17 @@
   // ---- Toast notifications ----
   function showToast(msg, type = "success") {
     const toast = document.createElement("div");
-    toast.className = `alert alert-${type === "success" ? "success" : "warning"}`;
-    toast.style.position = "fixed";
-    toast.style.top = "20px";
-    toast.style.right = "20px";
-    toast.style.zIndex = "9999";
-    toast.style.boxShadow = "0 4px 12px rgba(0,0,0,0.15)";
-    toast.style.padding = "12px 20px";
-    toast.style.margin = "0";
-    toast.innerHTML = `<i class="fa ${type === "success" ? "fa-check-circle" : "fa-warning"}"></i> ${msg}`;
+    toast.className = `sm-toast alert alert-${type === "success" ? "success" : "warning"}`;
+
+    const icon = document.createElement("i");
+    icon.className = `fa ${type === "success" ? "fa-check-circle" : "fa-warning"}`;
+    toast.appendChild(icon);
+    toast.appendChild(document.createTextNode(msg));
+
     document.body.appendChild(toast);
     setTimeout(() => {
-      toast.style.opacity = "0";
       toast.style.transition = "opacity 0.5s ease";
+      toast.style.opacity = "0";
       setTimeout(() => toast.remove(), 500);
     }, 3000);
   }
@@ -107,7 +105,8 @@
       return;
     }
 
-    const todayStr = new Date().toISOString().split('T')[0];
+    const _now = new Date();
+    const todayStr = `${_now.getFullYear()}-${String(_now.getMonth() + 1).padStart(2, "0")}-${String(_now.getDate()).padStart(2, "0")}`;
 
     tbody.innerHTML = visible.map((p, i) => {
       const idx = allPosts.indexOf(p);
@@ -170,7 +169,7 @@
         <td class="post-text-cell">
           <span class="post-text-view ${textClass}" data-idx="${idx}" tabindex="0">${escHtml(p.post_text)}</span>
           <textarea class="post-text-edit ${hasPlaceholder ? 'has-warning' : ''}" data-idx="${idx}">${escHtml(p.post_text)}</textarea>
-          <div class="char-count-wrap" style="font-size: 11px; color: #888; margin-top: 4px; display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap;">
+          <div class="char-count-wrap">
             <span><span class="char-count">${charCount}</span> characters</span>
             ${revertBtn}
           </div>
@@ -282,7 +281,8 @@
   function validateAllPosts() {
     let pastCount = 0;
     let placeholderCount = 0;
-    const todayStr = new Date().toISOString().split('T')[0];
+    const _now = new Date();
+    const todayStr = `${_now.getFullYear()}-${String(_now.getMonth() + 1).padStart(2, "0")}-${String(_now.getDate()).padStart(2, "0")}`;
 
     allPosts.forEach(p => {
       if (!p.enabled) return;
@@ -298,7 +298,7 @@
     if (!alertContainer) return;
 
     if (pastCount > 0 || placeholderCount > 0) {
-      let html = `<div class="alert alert-warning" style="margin-bottom: 12px;">`;
+      let html = `<div class="alert alert-warning sm-validation-alert">`;
       html += `<strong>Warning:</strong> `;
       const parts = [];
       if (pastCount > 0) {

--- a/socialmedia/static/socialmedia/js/settings.js
+++ b/socialmedia/static/socialmedia/js/settings.js
@@ -123,9 +123,27 @@
       const timeClass = isTimeModified ? "is-modified" : "";
       const textClass = isTextModified ? "is-modified" : "";
 
-      const refHtml = p.reference_date ? `<div class="dt-ref-date"><i class="fa fa-info-circle"></i> Ref: ${escHtml(p.reference_date)}</div>` : "";
       const dateWarn = isPast ? `<div class="validation-warning-badge"><i class="fa fa-exclamation-triangle"></i> Scheduled in past</div>` : "";
       const textWarn = hasPlaceholder ? `<div class="validation-warning-badge"><i class="fa fa-exclamation-triangle"></i> Unresolved placeholders</div>` : "";
+
+      let schedHtml = `<span class="sched-badge sched-na">N/A</span>`;
+      if (p.is_schedule_associated) {
+        if (p.event_schedule_display === "Unscheduled") {
+          schedHtml = `<span class="sched-badge sched-unscheduled"><i class="fa fa-clock-o"></i> Unscheduled</span>`;
+        } else if (p.event_schedule_display) {
+          const parts = p.event_schedule_display.split(" ");
+          if (parts.length >= 3) {
+            const dateStr = parts.slice(0, 3).join(" ");
+            const timeStr = parts.slice(3).join(" ");
+            schedHtml = `<div class="sched-box sched-active">
+              <div class="sched-date-row"><i class="fa fa-calendar"></i> ${escHtml(dateStr)}</div>
+              <div class="sched-time-row"><i class="fa fa-clock-o"></i> ${escHtml(timeStr)}</div>
+            </div>`;
+          } else {
+            schedHtml = `<span class="sched-badge sched-active"><i class="fa fa-calendar"></i> ${escHtml(p.event_schedule_display)}</span>`;
+          }
+        }
+      }
 
       const revertBtn = isTextModified ? `<button class="btn-revert-text" data-idx="${idx}" type="button"><i class="fa fa-undo"></i> Revert to default</button>` : "";
       const charCount = p.post_text.length;
@@ -138,15 +156,16 @@
         <td>
           <span class="type-badge type-${safeType}">${escHtml(p.type_label)}</span>
         </td>
-        <td>
-          <input type="date" class="form-control input-sm sm-date-input ${dateClass}" data-idx="${idx}" value="${escHtml(p.post_date)}">
-          ${isDateModified ? '<div class="is-modified-label">Modified</div>' : ''}
-          ${refHtml}
-          ${dateWarn}
+        <td class="event-schedule-cell">
+          ${schedHtml}
         </td>
         <td>
-          <input type="time" class="form-control input-sm sm-time-input ${timeClass}" data-idx="${idx}" value="${escHtml(p.post_time)}">
-          ${isTimeModified ? '<div class="is-modified-label">Modified</div>' : ''}
+          <div class="post-schedule-cell-wrap">
+            <input type="date" class="form-control input-sm sm-date-input ${dateClass}" data-idx="${idx}" value="${escHtml(p.post_date)}">
+            <input type="time" class="form-control input-sm sm-time-input ${timeClass}" data-idx="${idx}" value="${escHtml(p.post_time)}">
+            ${isDateModified || isTimeModified ? '<div class="is-modified-label">Modified</div>' : ''}
+            ${dateWarn}
+          </div>
         </td>
         <td class="post-text-cell">
           <span class="post-text-view ${textClass}" data-idx="${idx}" tabindex="0">${escHtml(p.post_text)}</span>
@@ -403,8 +422,8 @@
         ${[...Array(5)].map(() => `<tr class="skeleton-row">
           <td><div class="skeleton-bar" style="width:16px;height:16px;border-radius:3px;"></div></td>
           <td><div class="skeleton-bar" style="width:60px;"></div></td>
-          <td><div class="skeleton-bar" style="width:130px;"></div></td>
-          <td><div class="skeleton-bar" style="width:100px;"></div></td>
+          <td><div class="skeleton-bar" style="width:110px;"></div></td>
+          <td><div class="skeleton-bar" style="width:125px;"></div></td>
           <td><div class="skeleton-bar"></div></td>
         </tr>`).join("")}`;
     }

--- a/socialmedia/templates/socialmedia/settings.html
+++ b/socialmedia/templates/socialmedia/settings.html
@@ -78,12 +78,12 @@
         <tr>
           <th><input type="checkbox" id="chk-all" title="{% trans 'Toggle all' %}"></th>
           <th>{% trans "Type" %}</th>
+          <th><span title="{% trans 'Official date & time of the session on the event agenda schedule.' %}" style="cursor:help;border-bottom:1px dotted #ccc;">{% trans "Schedule Date & Time" %}</span></th>
           <th>
-            <span title="{% trans 'The date this post is scheduled to be published.' %}" style="cursor:help;border-bottom:1px dotted #ccc;">{% trans "Scheduled Date" %}</span>
+            <span title="{% trans 'The date & time this social media post is scheduled to be published.' %}" style="cursor:help;border-bottom:1px dotted #ccc;">{% trans "Post Schedule Date & Time" %}</span>
             <div style="font-size: 10px; font-weight: normal; color: #888; text-transform: none; margin-top: 2px;">{{ event.timezone }}</div>
           </th>
-          <th><span title="{% trans 'The time this post is scheduled to be published.' %}" style="cursor:help;border-bottom:1px dotted #ccc;">{% trans "Scheduled Time" %}</span></th>
-          <th>{% trans "Post Text" %} <span style="font-weight:400;color:#aaa;font-size:11px;">— {% trans "click to edit" %}</span></th>
+          <th>{% trans "Content" %} <span style="font-weight:400;color:#aaa;font-size:11px;">— {% trans "click to edit" %}</span></th>
         </tr>
       </thead>
       <tbody id="posts-tbody">
@@ -92,8 +92,8 @@
         <tr class="skeleton-row">
           <td><div class="skeleton-bar" style="width:16px;height:16px;border-radius:3px;"></div></td>
           <td><div class="skeleton-bar" style="width:60px;"></div></td>
-          <td><div class="skeleton-bar" style="width:80px;"></div></td>
-          <td><div class="skeleton-bar" style="width:50px;"></div></td>
+          <td><div class="skeleton-bar" style="width:110px;"></div></td>
+          <td><div class="skeleton-bar" style="width:125px;"></div></td>
           <td><div class="skeleton-bar" style="width:100%;"></div></td>
         </tr>
         {% endfor %}

--- a/socialmedia/templates/socialmedia/settings.html
+++ b/socialmedia/templates/socialmedia/settings.html
@@ -78,12 +78,12 @@
         <tr>
           <th><input type="checkbox" id="chk-all" title="{% trans 'Toggle all' %}"></th>
           <th>{% trans "Type" %}</th>
-          <th><span title="{% trans 'Official date & time of the session on the event agenda schedule.' %}" style="cursor:help;border-bottom:1px dotted #ccc;">{% trans "Schedule Date & Time" %}</span></th>
+          <th><span title="{% trans 'Official date & time of the session on the event agenda schedule.' %}" class="help-tooltip">{% trans "Schedule Date & Time" %}</span></th>
           <th>
-            <span title="{% trans 'The date & time this social media post is scheduled to be published.' %}" style="cursor:help;border-bottom:1px dotted #ccc;">{% trans "Post Schedule Date & Time" %}</span>
-            <div style="font-size: 10px; font-weight: normal; color: #888; text-transform: none; margin-top: 2px;">{{ event.timezone }}</div>
+            <span title="{% trans 'The date & time this social media post is scheduled to be published.' %}" class="help-tooltip">{% trans "Post Schedule Date & Time" %}</span>
+            <div class="th-timezone">{{ event.timezone }}</div>
           </th>
-          <th>{% trans "Content" %} <span style="font-weight:400;color:#aaa;font-size:11px;">— {% trans "click to edit" %}</span></th>
+          <th>{% trans "Content" %} <span class="th-hint">— {% trans "click to edit" %}</span></th>
         </tr>
       </thead>
       <tbody id="posts-tbody">

--- a/socialmedia/templates/socialmedia/settings.html
+++ b/socialmedia/templates/socialmedia/settings.html
@@ -45,14 +45,31 @@
 
   <!-- Action bar -->
   <div class="sm-actions">
-    <button id="btn-select-all" class="btn btn-default btn-sm">
-      <i class="fa fa-check-square-o"></i> {% trans "Select All" %}
-    </button>
-    <button id="btn-deselect-all" class="btn btn-default btn-sm">
-      <i class="fa fa-square-o"></i> {% trans "Deselect All" %}
-    </button>
+
+    <!-- Bulk schedule preset dropdown -->
+    <div class="bulk-schedule-wrap">
+      <select id="bulk-schedule-preset" class="form-control input-sm bulk-schedule-select">
+        <option value="">{% trans "Schedule preset..." %}</option>
+        <option value="0">{% trans "On event / session day" %}</option>
+        <option value="-1">{% trans "1 day before" %}</option>
+        <option value="-2">{% trans "2 days before" %}</option>
+        <option value="-7">{% trans "1 week before (7 days)" %}</option>
+        <option value="-14">{% trans "2 weeks before (14 days)" %}</option>
+        <option value="-30">{% trans "1 month before (30 days)" %}</option>
+        <option value="custom">{% trans "Custom..." %}</option>
+      </select>
+      <div id="bulk-schedule-custom-inputs" class="bulk-schedule-custom-inputs" style="display: none; align-items: center; gap: 4px;">
+        <input type="date" id="bulk-schedule-custom-date" class="form-control input-sm" style="width: 130px; display: inline-block;">
+        <input type="time" id="bulk-schedule-custom-time" class="form-control input-sm" style="width: 100px; display: inline-block;" value="09:00">
+      </div>
+      <button id="btn-apply-schedule" class="btn btn-default btn-sm" type="button">
+        {% trans "Apply" %}
+      </button>
+    </div>
     <span class="sm-count" id="selected-count">–</span>
   </div>
+
+  <div id="validation-alert-container" style="display: none; margin-bottom: 12px;"></div>
 
   <!-- Post table -->
   <div class="sm-table-wrap">
@@ -61,8 +78,11 @@
         <tr>
           <th><input type="checkbox" id="chk-all" title="{% trans 'Toggle all' %}"></th>
           <th>{% trans "Type" %}</th>
-          <th>{% trans "Date" %}</th>
-          <th>{% trans "Time" %}</th>
+          <th>
+            <span title="{% trans 'The date this post is scheduled to be published.' %}" style="cursor:help;border-bottom:1px dotted #ccc;">{% trans "Scheduled Date" %}</span>
+            <div style="font-size: 10px; font-weight: normal; color: #888; text-transform: none; margin-top: 2px;">{{ event.timezone }}</div>
+          </th>
+          <th><span title="{% trans 'The time this post is scheduled to be published.' %}" style="cursor:help;border-bottom:1px dotted #ccc;">{% trans "Scheduled Time" %}</span></th>
           <th>{% trans "Post Text" %} <span style="font-weight:400;color:#aaa;font-size:11px;">— {% trans "click to edit" %}</span></th>
         </tr>
       </thead>

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -77,7 +77,8 @@ def test_socialmedia_settings_view_post(
 
     assert response.status_code == 302
 
-    with scope(organizer=organizer):
+    with scope(organizer=organizer, event=event):
+        event.refresh_from_db()
         event.settings.flush()
         assert event.settings.get("socialmedia_default_hashtags") == "#pytest #testing"
         assert event.settings.get("socialmedia_cfp_offset") == "5"
@@ -135,3 +136,62 @@ def test_export_csv_view(logged_in_organizer_client, organizer, event, settings)
     content = response.content.decode("utf-8")
     assert "Hello world!" in content
     assert "Skipped post" not in content
+
+
+@pytest.mark.django_db
+def test_confirmed_submissions_and_schedule_metadata(
+    logged_in_organizer_client, organizer, event, settings
+):
+    settings.SITE_URL = "https://testserver"
+    try:
+        from eventyay.base.models.submission import Submission, SubmissionStates
+    except ImportError:
+        pytest.skip("Submission model not available")
+
+    with scope(organizer=organizer, event=event):
+        try:
+            from eventyay.base.models.type import SubmissionType
+        except ImportError:
+            from eventyay.base.models import SubmissionType
+
+        sub_type = event.submission_types.first() or SubmissionType.objects.create(
+            event=event, name="Talk"
+        )
+        _sub_confirmed = Submission.objects.create(
+            event=event,
+            submission_type=sub_type,
+            title="Confirmed Session",
+            state=SubmissionStates.CONFIRMED,
+            code="CONF1",
+        )
+        _sub_accepted = Submission.objects.create(
+            event=event,
+            submission_type=sub_type,
+            title="Accepted Only Session",
+            state=SubmissionStates.ACCEPTED,
+            code="ACCP1",
+        )
+
+    url = reverse(
+        "plugins:socialmedia:preview",
+        kwargs={"organizer": organizer.slug, "event": event.slug},
+    )
+    response = logged_in_organizer_client.get(url)
+    assert response.status_code == 200
+    posts = response.json().get("posts", [])
+
+    # Check fields in posts
+    for post in posts:
+        assert "event_schedule_display" in post
+        assert "is_schedule_associated" in post
+
+    session_posts = [p for p in posts if p["type"] == "session"]
+    # Should include confirmed session but not accepted session
+    titles = [p["post_text"] for p in session_posts]
+    assert any("Confirmed Session" in t for t in titles)
+    assert not any("Accepted Only Session" in t for t in titles)
+
+    # Check unscheduled status
+    conf_post = next(p for p in session_posts if "Confirmed Session" in p["post_text"])
+    assert conf_post["event_schedule_display"] == "Unscheduled"
+    assert conf_post["is_schedule_associated"] is True


### PR DESCRIPTION


#### **Overview**
Polishes the social media posts preview table and adds bulk action presets for easier scheduling.

<img width="1452" height="853" alt="1" src="https://github.com/user-attachments/assets/6a63b16b-c25f-4443-bc34-628ad7972dae" />


#### **Key Improvements**
- **Bulk Scheduling Preset Dropdown**: Adds an inline dropdown to easily reschedule selected posts relative to the event/session date (e.g., 1 or 2 days before) or with a custom date-time.
- **Inline Date Pickers**: Replaces static date/time text with interactive date and time inputs.
- **Promotable Unscheduled Sessions**: Confirmed sessions that have not yet been assigned a scheduled time on the agenda are still generated as drafts (flagged as `"Unscheduled"` under schedule metadata) so they can be previewed/customized.
- **Clean Styling (No Inline CSS & Safe HTML)**: Replaced inline styles and `!important` declarations with dedicated CSS classes (`.sm-toast`, `.char-count-wrap`, `.sm-validation-alert`), and refactored toast alerts to use safe DOM text nodes to prevent XSS.
- closes : #23 